### PR TITLE
Adjusted DiscordHostedService Initialization Approach

### DIFF
--- a/DisCatSharp.Hosting/DiscordHostedService.cs
+++ b/DisCatSharp.Hosting/DiscordHostedService.cs
@@ -153,7 +153,6 @@ namespace DisCatSharp.Hosting
             try
             {
                 this.Client = this.Configuration.BuildClient(this._botSection);
-                this.Client.Services = this.ServiceProvider;
             }
             catch (Exception ex)
             {

--- a/DisCatSharp/Clients/BaseDiscordClient.cs
+++ b/DisCatSharp/Clients/BaseDiscordClient.cs
@@ -147,7 +147,7 @@ namespace DisCatSharp
 
             this.BotLibrary = "DisCatSharp";
 
-            this.Services = config.Services;
+            this.Services = config.ServiceProvider;
         }
 
         /// <summary>

--- a/DisCatSharp/DiscordConfiguration.cs
+++ b/DisCatSharp/DiscordConfiguration.cs
@@ -216,13 +216,23 @@ namespace DisCatSharp
         /// <para>This allows passing data around without resorting to static members.</para>
         /// <para>Defaults to null.</para>
         /// </summary>
-        public IServiceProvider Services { internal get; set; } = new ServiceCollection().BuildServiceProvider(true);
+        public IServiceProvider ServiceProvider { internal get; set; } = new ServiceCollection().BuildServiceProvider(true);
 
         /// <summary>
         /// Creates a new configuration with default values.
         /// </summary>
         public DiscordConfiguration()
         { }
+
+        /// <summary>
+        /// Utilized via Dependency Injection Pipeline
+        /// </summary>
+        /// <param name="provider"></param>
+        [ActivatorUtilitiesConstructor]
+        public DiscordConfiguration(IServiceProvider provider)
+        {
+            this.ServiceProvider = provider;
+        }
 
         /// <summary>
         /// Creates a clone of another discord configuration.
@@ -252,7 +262,7 @@ namespace DisCatSharp
             this.UseCanary = other.UseCanary;
             this.AutoRefreshChannelCache = other.AutoRefreshChannelCache;
             this.ApiVersion = other.ApiVersion;
-            this.Services = other.Services;
+            this.ServiceProvider = other.ServiceProvider;
         }
     }
 }


### PR DESCRIPTION
Separated the extension initialization and client creation

Extension method is overridable, and invoked after connecting
Exposed Provider / Configuration to derived classes instead of having to pass it around all the time

Added a DI Constructor for DiscordConfiguration.
This is used by ActivatorUtilities to auto insert things via ServiceProvider, thus allowing DI to flow properly rather than manually setting the client's service provider

Updated Services to ServiceProvider for consistency