### PR TITLE
Add support for link buttons when fetching components

### DIFF
--- a/DisCatSharp/Enums/Interaction/ButtonStyle.cs
+++ b/DisCatSharp/Enums/Interaction/ButtonStyle.cs
@@ -46,5 +46,10 @@ namespace DisCatSharp.Enums
         /// Red button.
         /// </summary>
         Danger = 4,
+
+        /// <summary>
+        /// Link Button.
+        /// </summary>
+        Link = 5
     }
 }

--- a/DisCatSharp/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DisCatSharp/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -60,19 +60,30 @@ namespace DisCatSharp.Net.Serialization
 
             var job = JObject.Load(reader);
             var type = job["type"]?.ToObject<ComponentType>();
+            var style = job["style"]?.ToObject<ButtonStyle>();
 
             if (type == null)
                 throw new ArgumentException($"Value {reader} does not have a component type specifier");
 
-            var cmp = type switch
+            DiscordComponent cmp;
+            if (type is ComponentType.Button && style is not null)
             {
-                ComponentType.ActionRow => new DiscordActionRowComponent(),
-                ComponentType.Button => new DiscordButtonComponent(),
-                ComponentType.Select => new DiscordSelectComponent(),
-                ComponentType.InputText => new DiscordTextComponent(),
-                _ => new DiscordComponent() { Type = type.Value }
-            };
-
+                cmp = style switch
+                {
+                    ButtonStyle.Link => new DiscordLinkButtonComponent(),
+                    _ => new DiscordButtonComponent()
+                };
+            }
+            else
+            {
+                cmp = type switch
+                {
+                    ComponentType.ActionRow => new DiscordActionRowComponent(),
+                    ComponentType.Select => new DiscordSelectComponent(),
+                    ComponentType.InputText => new DiscordTextComponent(),
+                    _ => new DiscordComponent() { Type = type.Value }
+                };
+            }
             // Populate the existing component with the values in the JObject. This avoids a recursive JsonConverter loop
             using var jreader = job.CreateReader();
             serializer.Populate(jreader, cmp);

--- a/DisCatSharp/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DisCatSharp/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -60,14 +60,14 @@ namespace DisCatSharp.Net.Serialization
 
             var job = JObject.Load(reader);
             var type = job["type"]?.ToObject<ComponentType>();
-            var style = job["style"]?.ToObject<ButtonStyle>();
 
             if (type == null)
                 throw new ArgumentException($"Value {reader} does not have a component type specifier");
 
             DiscordComponent cmp;
-            if (type is ComponentType.Button && style is not null)
+            if (type is ComponentType.Button)
             {
+                var style = job["style"]?.ToObject<ButtonStyle>();
                 cmp = style switch
                 {
                     ButtonStyle.Link => new DiscordLinkButtonComponent(),


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Currently Link buttons are fetched as buttons due to the json converter not checking the style.
This PR aims to fix this and allow link buttons to be fetched as DiscordLinkButtonComponents instead of DiscordButtonComponents.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a link button to a message and made sure it's fetched back as a link button
- [x] Added both a link button and normal button and made sure they're fetched back as the correct class

**Test Configuration**:
* Firmware version:
* Hardware: Test bot running on Mac OS Monetary
* Toolchain:
* SDK: .Net 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
