### PR TITLE
Fix sub options not being added to commands inside of two command groups

### DIFF
--- a/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
+++ b/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
@@ -349,7 +349,7 @@ namespace DisCatSharp.ApplicationCommands
 							subSubDescriptionLocalizations = subSubCommandTranslation.DescriptionTranslations;
 						}
 
-						var subsubpayload = new DiscordApplicationCommandOption(commatt.Name, commatt.Description, ApplicationCommandOptionType.SubCommand, null, null, (localizisedOptions != null && localizisedOptions.Any() ? localizisedOptions : null) ?? (options != null && options.Any() ? options : null), nameLocalizations: subSubNameLocalizations, descriptionLocalizations: subSubDescriptionLocalizations);
+						var subsubpayload = new DiscordApplicationCommandOption(commatt.Name, commatt.Description, ApplicationCommandOptionType.SubCommand, null, null, (localizisedOptions != null && localizisedOptions.Any() ? localizisedOptions : null) ?? (suboptions != null && suboptions.Any() ? suboptions : null), nameLocalizations: subSubNameLocalizations, descriptionLocalizations: subSubDescriptionLocalizations);
 						options.Add(subsubpayload);
 						commandmethods.Add(new KeyValuePair<string, MethodInfo>(commatt.Name, subsubmethod));
 						currentMethods.Add(new KeyValuePair<string, MethodInfo>(commatt.Name, subsubmethod));


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Slash commands that sit under two slash command groups where not having their options registered correctly.
Example command
```cs
[SlashCommandGroup("top_level_command", "top level group")]
public class MySlashCommandGroups : ApplicationCommandsModule
{
    [SlashCommandGroup("mid_level", "mid level group")]
    public class MidLevelGroup : ApplicationCommandsModule
    {
        [SlashCommand("test_command", "test commands")]
        public async Task TestCommand(InteractionContext ctx,
            [Option("repeat_this", "repeats the text")] string repeatMe)
        {
            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
                .WithContent(repeatMe));
        }
    }

    [SlashCommandGroup("mid_level_two", "mid level group two")]
    public class MidLevelGroupTwo : ApplicationCommandsModule
    {
        [SlashCommand("reverse_test", "test command to reverse a string")]
        public async Task TestReverseCommand(InteractionContext ctx,
            [Option("reverse_this", "reverses the text")] string reverseMe)
        {
            char[] charArray = reverseMe.ToCharArray();
            Array.Reverse( charArray );
            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
                new DiscordInteractionResponseBuilder()
                    .WithContent(new string(charArray)));
        } 
    }
}
```
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested the above commands register correctly and are functional
- [X] Tested existing commands register correctly and are functional

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK: .Net 6

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
