### PR TITLE
Embed Fields Upgrade

### DIFF
--- a/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
@@ -397,9 +397,38 @@ namespace DisCatSharp.Entities
 		/// <param name="fields">The fields to add.</param>
 		/// <returns>This embed builder.</returns>
 		public DiscordEmbedBuilder AddFields(IEnumerable<DiscordEmbedField> fields)
-		{
-			fields.Select(f => this.AddField(f));
+			=> fields.Aggregate(this, (x, y) => x.AddField(y));
 
+		/// <summary>
+		/// Removes a field from this embed, if it is part of it.
+		/// </summary>
+		/// <param name="field">The field to remove.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbedBuilder RemoveField(DiscordEmbedField field)
+		{
+			this._fields.Remove(field);
+			return this;
+		}
+
+		/// <summary>
+		/// Removes multiple fields from this embed, if they are part of it.
+		/// </summary>
+		/// <param name="fields">The fields to remove.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbedBuilder RemoveFields(params DiscordEmbedField[] fields)
+		{
+			this.RemoveFields((IEnumerable<DiscordEmbedField>)fields);
+			return this;
+		}
+
+		/// <summary>
+		/// Removes multiple fields from this embed, if they are part of it.
+		/// </summary>
+		/// <param name="fields">The fields to remove.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbed RemoveFields(IEnumerable<DiscordEmbedField> fields)
+		{
+			this._fields.RemoveAll(x => fields.Contains(x));
 			return this;
 		}
 

--- a/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
@@ -366,34 +366,40 @@ namespace DisCatSharp.Entities
 		/// <param name="inline">Whether the field is to be inline or not.</param>
 		/// <returns>This embed builder.</returns>
 		public DiscordEmbedBuilder AddField(string name, string value, bool inline = false)
+			=> this.AddField(new DiscordEmbedField(name, value, inline));
+
+		/// <summary>
+		/// Adds a field to this embed.
+		/// </summary>
+		/// <param name="field">The field to add.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbedBuilder AddField(DiscordEmbedField field)
 		{
-			if (string.IsNullOrWhiteSpace(name))
-			{
-				if (name == null)
-					throw new ArgumentNullException(nameof(name));
-				throw new ArgumentException("Name cannot be empty or whitespace.", nameof(name));
-			}
-			if (string.IsNullOrWhiteSpace(value))
-			{
-				if (value == null)
-					throw new ArgumentNullException(nameof(value));
-				throw new ArgumentException("Value cannot be empty or whitespace.", nameof(value));
-			}
-
-			if (name.Length > 256)
-				throw new ArgumentException("Embed field name length cannot exceed 256 characters.");
-			if (value.Length > 1024)
-				throw new ArgumentException("Embed field value length cannot exceed 1024 characters.");
-
 			if (this._fields.Count >= 25)
 				throw new InvalidOperationException("Cannot add more than 25 fields.");
 
-			this._fields.Add(new DiscordEmbedField
-			{
-				Inline = inline,
-				Name = name,
-				Value = value
-			});
+			this._fields.Add(field);
+
+			return this;
+		}
+
+		/// <summary>
+		/// Adds multiple fields to this embed.
+		/// </summary>
+		/// <param name="fields">The fields to add.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbedBuilder AddFields(params DiscordEmbedField[] fields)
+			=> this.AddFields((IEnumerable<DiscordEmbedField>)fields);
+
+		/// <summary>
+		/// Adds multiple fields to this embed.
+		/// </summary>
+		/// <param name="fields">The fields to add.</param>
+		/// <returns>This embed builder.</returns>
+		public DiscordEmbedBuilder AddFields(IEnumerable<DiscordEmbedField> fields)
+		{
+			fields.Select(f => this.AddField(f));
+
 			return this;
 		}
 

--- a/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedBuilder.cs
@@ -365,6 +365,7 @@ namespace DisCatSharp.Entities
 		/// <param name="value">Value of the field to add.</param>
 		/// <param name="inline">Whether the field is to be inline or not.</param>
 		/// <returns>This embed builder.</returns>
+		[Obsolete("DiscordEmbedFields should be constructed manually")]
 		public DiscordEmbedBuilder AddField(string name, string value, bool inline = false)
 			=> this.AddField(new DiscordEmbedField(name, value, inline));
 

--- a/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
@@ -91,7 +91,7 @@ namespace DisCatSharp.Entities
 		/// <param name="name"><see cref="Name"/></param>
 		/// <param name="value"><see cref="Value"/></param>
 		/// <param name="inline"><see cref="Inline"/></param>
-		public DiscordEmbedField(string name, string value, bool inline)
+		public DiscordEmbedField(string name, string value, bool inline = false)
 		{
 			this.Name = name;
 			this.Value = value;

--- a/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+
 using Newtonsoft.Json;
 
 namespace DisCatSharp.Entities
@@ -29,17 +31,51 @@ namespace DisCatSharp.Entities
 	/// </summary>
 	public sealed class DiscordEmbedField
 	{
+		private string _name;
+
 		/// <summary>
 		/// Gets the name of the field.
 		/// </summary>
 		[JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
-		public string Name { get; set; }
+		public string Name { get => this._name;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+				{
+					if (value == null)
+						throw new ArgumentNullException(nameof(value));
+					throw new ArgumentException("Name cannot be empty or whitespace.", nameof(value));
+				}
+
+				if (value.Length > 256)
+					throw new ArgumentException("Embed field name length cannot exceed 256 characters.");
+
+				this._name = value;
+			}
+		}
+
+		private string _value;
 
 		/// <summary>
 		/// Gets the value of the field.
 		/// </summary>
 		[JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
-		public string Value { get; set; }
+		public string Value { get => this._value;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+				{
+					if (value == null)
+						throw new ArgumentNullException(nameof(value));
+					throw new ArgumentException("Value cannot be empty or whitespace.", nameof(value));
+				}
+
+				if (value.Length > 1024)
+					throw new ArgumentException("Embed field value length cannot exceed 1024 characters.");
+
+				this._value = value;
+			}
+		}
 
 		/// <summary>
 		/// Gets whether or not this field should display inline.
@@ -50,7 +86,11 @@ namespace DisCatSharp.Entities
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DiscordEmbedField"/> class.
 		/// </summary>
-		internal DiscordEmbedField()
-		{ }
+		public DiscordEmbedField(string name, string value, bool inline)
+		{
+			this.Name = name;
+			this.Value = value;
+			this.Inline = inline;
+		}
 	}
 }

--- a/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
+++ b/DisCatSharp/Entities/Embed/DiscordEmbedField.cs
@@ -34,7 +34,8 @@ namespace DisCatSharp.Entities
 		private string _name;
 
 		/// <summary>
-		/// Gets the name of the field.
+		/// The name of the field.
+		/// Must be non-null, non-empty and &lt;= 256 characters.
 		/// </summary>
 		[JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
 		public string Name { get => this._name;
@@ -57,7 +58,8 @@ namespace DisCatSharp.Entities
 		private string _value;
 
 		/// <summary>
-		/// Gets the value of the field.
+		/// The value of the field.
+		/// Must be non-null, non-empty and &lt;= 1024 characters.
 		/// </summary>
 		[JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
 		public string Value { get => this._value;
@@ -78,7 +80,7 @@ namespace DisCatSharp.Entities
 		}
 
 		/// <summary>
-		/// Gets whether or not this field should display inline.
+		/// Whether or not this field should display inline.
 		/// </summary>
 		[JsonProperty("inline", NullValueHandling = NullValueHandling.Ignore)]
 		public bool Inline { get; set; }
@@ -86,6 +88,9 @@ namespace DisCatSharp.Entities
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DiscordEmbedField"/> class.
 		/// </summary>
+		/// <param name="name"><see cref="Name"/></param>
+		/// <param name="value"><see cref="Value"/></param>
+		/// <param name="inline"><see cref="Inline"/></param>
 		public DiscordEmbedField(string name, string value, bool inline)
 		{
 			this.Name = name;


### PR DESCRIPTION
# Description

Currently, given a `DiscordEmbedBuilder` `builder` you can modify the contents of its fields without regard for the fields' invariants using the following: `builder.Fields[0].Name = null`.

This PR alleviates this by moving all necessary invariants to the setters of the appropriate variables. Additionally the user is now allowed to utilize `DiscordEmbedField`s directly, as this can be useful, e.g. when wanting to create a collection of them via Linq mapping.

I've decided to keep the original `AddField` method around, while marking it with `Obsolete` as to both maintain backwards compatibility as well as indicate to users that they should utilize the manual construction of fields. This can of course be changed as requested.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Due to the triviality of the changes I have not conducted any testing. If deemed necessary I could just write up some equally trivial test cases next to the other tests in the project.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
