### PR TITLE
Fix threads

### DIFF
--- a/DisCatSharp/Entities/Channel/DiscordChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordChannel.cs
@@ -1020,11 +1020,11 @@ namespace DisCatSharp.Entities
 					: type == ChannelType.PrivateThread
 						? Utilities.CheckThreadPrivateFeature(this.Guild)
 							? Utilities.CheckThreadAutoArchiveDurationFeature(this.Guild, autoArchiveDuration)
-								? await this.Discord.ApiClient.CreateThreadWithoutMessageAsync(this.Id, name, autoArchiveDuration, type, rateLimitPerUser, reason)
+								? await this.Discord.ApiClient.CreateThreadAsync(this.Id, null, name, autoArchiveDuration, type, rateLimitPerUser, reason)
 								: throw new NotSupportedException($"Cannot modify ThreadAutoArchiveDuration. Guild needs boost tier {(autoArchiveDuration == ThreadAutoArchiveDuration.ThreeDays ? "one" : "two")}.")
 							: throw new NotSupportedException($"Cannot create a private thread. Guild needs to be boost tier two.")
 						: Utilities.CheckThreadAutoArchiveDurationFeature(this.Guild, autoArchiveDuration)
-							? await this.Discord.ApiClient.CreateThreadWithoutMessageAsync(this.Id, name, autoArchiveDuration, this.Type == ChannelType.News ? ChannelType.NewsThread : ChannelType.PublicThread, rateLimitPerUser, reason)
+							? await this.Discord.ApiClient.CreateThreadAsync(this.Id, null, name, autoArchiveDuration, this.Type == ChannelType.News ? ChannelType.NewsThread : ChannelType.PublicThread, rateLimitPerUser, reason)
 							: throw new NotSupportedException($"Cannot modify ThreadAutoArchiveDuration. Guild needs boost tier {(autoArchiveDuration == ThreadAutoArchiveDuration.ThreeDays ? "one" : "two")}.");
 
 		/// <summary>

--- a/DisCatSharp/Entities/Message/DiscordMessage.cs
+++ b/DisCatSharp/Entities/Message/DiscordMessage.cs
@@ -622,7 +622,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="System.NotSupportedException">Thrown when the <see cref="ThreadAutoArchiveDuration"/> cannot be modified.</exception>
 		public async Task<DiscordThreadChannel> CreateThreadAsync(string name, ThreadAutoArchiveDuration autoArchiveDuration = ThreadAutoArchiveDuration.OneHour, int? rateLimitPerUser = null, string reason = null) =>
 			Utilities.CheckThreadAutoArchiveDurationFeature(this.Channel.Guild, autoArchiveDuration)
-				? await this.Discord.ApiClient.CreateThreadWithMessageAsync(this.ChannelId, this.Id, name, autoArchiveDuration, rateLimitPerUser, reason)
+				? await this.Discord.ApiClient.CreateThreadAsync(this.ChannelId, this.Id, name, autoArchiveDuration, this.Channel.Type == ChannelType.News ? ChannelType.NewsThread : ChannelType.PublicThread, rateLimitPerUser, reason)
 				: throw new NotSupportedException($"Cannot modify ThreadAutoArchiveDuration. Guild needs boost tier {(autoArchiveDuration == ThreadAutoArchiveDuration.ThreeDays ? "one" : "two")}.");
 
 		/// <summary>

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -3906,20 +3906,17 @@ namespace DisCatSharp.Net
 			if (!string.IsNullOrWhiteSpace(reason))
 				headers.Add(REASON_HEADER_NAME, reason);
 
-			string route;
-			RateLimitBucket bucket;
-			string path;
+			var route = $"{Endpoints.CHANNELS}/:channel_id";
 			if (messageId is not null)
-			{
-				route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.THREADS}";
-				bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId, message_id = messageId }, out path);
-			}
-			else
-			{
-				route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}";
-				bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId }, out path);
-			}
+				route += $"{Endpoints.MESSAGES}/:message_id";
+			route += Endpoints.THREADS;
 
+			object param = messageId is null
+				? new {channel_id = channelId}
+				: new {channel_id = channelId, message_id = messageId};
+
+			var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, param, out var path);
+			
 			var url = Utilities.GetApiUriFor(path, this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld));
 

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -3882,48 +3882,17 @@ namespace DisCatSharp.Net
 		#region Threads
 
 		/// <summary>
-		/// Creates the thread with message.
+		/// Creates the thread.
 		/// </summary>
 		/// <param name="channelId">The channel id to create the thread in.</param>
-		/// <param name="messageId">The message id to create the thread from.</param>
-		/// <param name="name">The name of the thread.</param>
-		/// <param name="autoArchiveDuration">The auto_archive_duration for the thread.</param>
-		/// <param name="rateLimitPerUser">The rate limit per user.</param>
-		/// <param name="reason">The reason.</param>
-		internal async Task<DiscordThreadChannel> CreateThreadWithMessageAsync(ulong channelId, ulong messageId, string name, ThreadAutoArchiveDuration autoArchiveDuration, int? rateLimitPerUser, string reason = null)
-		{
-			var pld = new RestThreadChannelCreatePayload
-			{
-				Name = name,
-				AutoArchiveDuration = autoArchiveDuration,
-				PerUserRateLimit = rateLimitPerUser
-			};
-
-			var headers = Utilities.GetBaseHeaders();
-			if (!string.IsNullOrWhiteSpace(reason))
-				headers.Add(REASON_HEADER_NAME, reason);
-
-			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.THREADS}";
-			var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId, message_id = messageId }, out var path);
-
-			var url = Utilities.GetApiUriFor(path, this.Discord.Configuration);
-			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld));
-
-			var threadChannel = JsonConvert.DeserializeObject<DiscordThreadChannel>(res.Response);
-
-			return threadChannel;
-		}
-
-		/// <summary>
-		/// Creates the thread without a message.
-		/// </summary>
-		/// <param name="channelId">The channel id to create the thread in.</param>
+		/// <param name="messageId">The optional message id to create the thread from.</param>
 		/// <param name="name">The name of the thread.</param>
 		/// <param name="autoArchiveDuration">The auto_archive_duration for the thread.</param>
 		/// <param name="type">Can be either <see cref="ChannelType.PublicThread"/> or <see cref="ChannelType.PrivateThread"/>.</param>
 		/// <param name="rateLimitPerUser">The rate limit per user.</param>
 		/// <param name="reason">The reason.</param>
-		internal async Task<DiscordThreadChannel> CreateThreadWithoutMessageAsync(ulong channelId, string name, ThreadAutoArchiveDuration autoArchiveDuration, ChannelType type = ChannelType.PublicThread, int? rateLimitPerUser = null, string reason = null)
+		internal async Task<DiscordThreadChannel> CreateThreadAsync(ulong channelId, ulong? messageId, string name,
+			ThreadAutoArchiveDuration autoArchiveDuration, ChannelType type, int? rateLimitPerUser, string reason)
 		{
 			var pld = new RestThreadChannelCreatePayload
 			{
@@ -3937,13 +3906,26 @@ namespace DisCatSharp.Net
 			if (!string.IsNullOrWhiteSpace(reason))
 				headers.Add(REASON_HEADER_NAME, reason);
 
-			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}";
-			var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId }, out var path);
+			string route;
+			RateLimitBucket bucket;
+			string path;
+			if (messageId is not null)
+			{
+				route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.THREADS}";
+				bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId, message_id = messageId }, out path);
+			}
+			else
+			{
+				route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}";
+				bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id = channelId }, out path);
+			}
 
 			var url = Utilities.GetApiUriFor(path, this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld));
 
 			var threadChannel = JsonConvert.DeserializeObject<DiscordThreadChannel>(res.Response);
+
+			threadChannel.Discord = this.Discord;
 
 			return threadChannel;
 		}


### PR DESCRIPTION
# Description

Fixed threads not having a `Discord` object assigned on creation, leading to `NullReferenceException` upon using them.

I also fixed threads created from messages not including a thread type in their payload, although I'm unsure if this actually caused issues in practice.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Simply created a test bot and tested the associated calls (`DiscordChannel.CreateThreadAsync` and `DiscordMessage.CreateChannelAsync`) manually.

I'm not sure if there is some test driver that supports automatically testing this kind of thing? If there is, let me know!

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
