### PR TITLE
Fix spelling in docs & code

### DIFF
--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsConfiguration.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsConfiguration.cs
@@ -60,7 +60,7 @@ namespace DisCatSharp.ApplicationCommands
 
 		/// <summary>
 		/// Automatically defer all responses.
-		/// <note type="note">If you enable this, you can't use CreateResponse. Use EditResponse instad.</note>
+		/// <note type="note">If you enable this, you can't use CreateResponse. Use EditResponse instead.</note>
 		/// </summary>
 		public bool AutoDefer { internal get; set; } = false;
 

--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
@@ -1411,7 +1411,7 @@ namespace DisCatSharp.ApplicationCommands
 		}
 
 		/// <summary>
-		/// Runs the preexecution checks.
+		/// Runs the pre-execution checks.
 		/// </summary>
 		/// <param name="method">The method info.</param>
 		/// <param name="context">The base context.</param>

--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
@@ -452,8 +452,8 @@ namespace DisCatSharp.ApplicationCommands
 		/// Method for registering commands for a target from modules.
 		/// </summary>
 		/// <param name="types">The types.</param>
-		/// <param name="guildid">The optional guild id.</param>
-		private void RegisterCommands(IEnumerable<ApplicationCommandsModuleConfiguration> types, ulong? guildid)
+		/// <param name="guildId">The optional guild id.</param>
+		private void RegisterCommands(IEnumerable<ApplicationCommandsModuleConfiguration> types, ulong? guildId)
 		{
 			//Initialize empty lists to be added to the global ones at the end
 			var commandMethods = new List<CommandMethod>();
@@ -496,22 +496,22 @@ namespace DisCatSharp.ApplicationCommands
 							groupTranslations = JsonConvert.DeserializeObject<List<GroupTranslator>>(ctx.Translations);
 						}
 
-						var slashGroupsTulpe = NestedCommandWorker.ParseSlashGroupsAsync(type, classes, guildid, groupTranslations).Result;
+						var slashGroupsTuple = NestedCommandWorker.ParseSlashGroupsAsync(type, classes, guildId, groupTranslations).Result;
 
-						if (slashGroupsTulpe.applicationCommands != null && slashGroupsTulpe.applicationCommands.Any())
-							updateList.AddRange(slashGroupsTulpe.applicationCommands);
+						if (slashGroupsTuple.applicationCommands != null && slashGroupsTuple.applicationCommands.Any())
+							updateList.AddRange(slashGroupsTuple.applicationCommands);
 
-						if (slashGroupsTulpe.commandTypeSources != null && slashGroupsTulpe.commandTypeSources.Any())
-							commandTypeSources.AddRange(slashGroupsTulpe.commandTypeSources);
+						if (slashGroupsTuple.commandTypeSources != null && slashGroupsTuple.commandTypeSources.Any())
+							commandTypeSources.AddRange(slashGroupsTuple.commandTypeSources);
 
-						if (slashGroupsTulpe.singletonModules != null && slashGroupsTulpe.singletonModules.Any())
-							s_singletonModules.AddRange(slashGroupsTulpe.singletonModules);
+						if (slashGroupsTuple.singletonModules != null && slashGroupsTuple.singletonModules.Any())
+							s_singletonModules.AddRange(slashGroupsTuple.singletonModules);
 
-						if (slashGroupsTulpe.groupCommands != null && slashGroupsTulpe.groupCommands.Any())
-							groupCommands.AddRange(slashGroupsTulpe.groupCommands);
+						if (slashGroupsTuple.groupCommands != null && slashGroupsTuple.groupCommands.Any())
+							groupCommands.AddRange(slashGroupsTuple.groupCommands);
 
-						if (slashGroupsTulpe.subGroupCommands != null && slashGroupsTulpe.subGroupCommands.Any())
-							subGroupCommands.AddRange(slashGroupsTulpe.subGroupCommands);
+						if (slashGroupsTuple.subGroupCommands != null && slashGroupsTuple.subGroupCommands.Any())
+							subGroupCommands.AddRange(slashGroupsTuple.subGroupCommands);
 
 						//Handles methods and context menus, only if the module isn't a group itself
 						if (module.GetCustomAttribute<SlashCommandGroupAttribute>() == null)
@@ -526,7 +526,7 @@ namespace DisCatSharp.ApplicationCommands
 							//Slash commands
 							var methods = module.DeclaredMethods.Where(x => x.GetCustomAttribute<SlashCommandAttribute>() != null);
 
-							var slashCommands = CommandWorker.ParseBasicSlashCommandsAsync(type, methods, guildid, commandTranslations).Result;
+							var slashCommands = CommandWorker.ParseBasicSlashCommandsAsync(type, methods, guildId, commandTranslations).Result;
 
 							if (slashCommands.applicationCommands != null && slashCommands.applicationCommands.Any())
 								updateList.AddRange(slashCommands.applicationCommands);
@@ -575,7 +575,7 @@ namespace DisCatSharp.ApplicationCommands
 
 						try
 						{
-							if (guildid == null)
+							if (guildId == null)
 							{
 								if (updateList != null && updateList.Any())
 								{
@@ -603,11 +603,11 @@ namespace DisCatSharp.ApplicationCommands
 							{
 								if (updateList != null && updateList.Any())
 								{
-									var regCommands = RegistrationWorker.RegisterGuilldCommandsAsync(guildid.Value, updateList).Result;
+									var regCommands = RegistrationWorker.RegisterGuildCommandsAsync(guildId.Value, updateList).Result;
 									var actualCommands = regCommands.Distinct().ToList();
 									commands.AddRange(actualCommands);
-									GuildCommandsInternal.Add(guildid.Value, actualCommands);
-									if (this.Client.Guilds.TryGetValue(guildid.Value, out var guild))
+									GuildCommandsInternal.Add(guildId.Value, actualCommands);
+									if (this.Client.Guilds.TryGetValue(guildId.Value, out var guild))
 									{
 										guild.InternalRegisteredApplicationCommands = new();
 										guild.InternalRegisteredApplicationCommands.AddRange(actualCommands);
@@ -616,15 +616,15 @@ namespace DisCatSharp.ApplicationCommands
 								}
 								else
 								{
-									foreach (var cmd in GuildDiscordCommands[guildid.Value])
+									foreach (var cmd in GuildDiscordCommands[guildId.Value])
 									{
 										try
 										{
-											await this.Client.DeleteGuildApplicationCommandAsync(guildid.Value, cmd.Id);
+											await this.Client.DeleteGuildApplicationCommandAsync(guildId.Value, cmd.Id);
 										}
 										catch (NotFoundException)
 										{
-											this.Client.Logger.Log(ApplicationCommandsLogLevel, $"Could not delete guild command {cmd.Id} in guild {guildid.Value}. Please clean up manually");
+											this.Client.Logger.Log(ApplicationCommandsLogLevel, $"Could not delete guild command {cmd.Id} in guild {guildId.Value}. Please clean up manually");
 										}
 									}
 								}
@@ -632,7 +632,7 @@ namespace DisCatSharp.ApplicationCommands
 						}
 						catch (UnauthorizedException ex)
 						{
-							this.Client.Logger.LogError($"Could not register application commands for guild {guildid}.\nError: {ex.JsonMessage}");
+							this.Client.Logger.LogError($"Could not register application commands for guild {guildId}.\nError: {ex.JsonMessage}");
 							return;
 						}
 
@@ -651,7 +651,7 @@ namespace DisCatSharp.ApplicationCommands
 
 								var source = commandTypeSources.FirstOrDefault(f => f.Key == com.Method.DeclaringType);
 
-								if(guildid != null)
+								if(guildId != null)
 								{
 									var (success, commandId, permissions) = PermissionWorker.ResolvePermissions(types, command.Id, com.Name, source.Value, source.Key);
 
@@ -690,7 +690,7 @@ namespace DisCatSharp.ApplicationCommands
 								{
 									var source = commandTypeSources.FirstOrDefault(f => f.Key == gCom.Value.DeclaringType);
 
-									if (guildid != null)
+									if (guildId != null)
 									{
 										var (success, commandId, permissions) = PermissionWorker.ResolvePermissions(types, groupCom.CommandId, gCom.Key, source.Key, source.Value);
 
@@ -731,7 +731,7 @@ namespace DisCatSharp.ApplicationCommands
 									{
 										var source = commandTypeSources.FirstOrDefault(f => f.Key == gCom.Value.DeclaringType);
 
-										if (guildid != null)
+										if (guildId != null)
 										{
 											var (success, commandId, permissions) = PermissionWorker.ResolvePermissions(types, subCom.CommandId, gCom.Key, source.Key, source.Value);
 
@@ -769,7 +769,7 @@ namespace DisCatSharp.ApplicationCommands
 
 								var source = commandTypeSources.First(f => f.Key == cmCom.Method.DeclaringType);
 
-								if (guildid != null)
+								if (guildId != null)
 								{
 									var (success, commandId, permissions) = PermissionWorker.ResolvePermissions(types, command.Id, cmCom.Name, source.Value, source.Key);
 
@@ -801,7 +801,7 @@ namespace DisCatSharp.ApplicationCommands
 							}
 						}
 						
-						if (guildid != null && overwrites != null && overwrites.Any())
+						if (guildId != null && overwrites != null && overwrites.Any())
 						{
 							if (overwrites.Any(x => x.Id == 0))
 							{
@@ -812,8 +812,8 @@ namespace DisCatSharp.ApplicationCommands
 
 							try
 							{
-								var perms = await PermissionWorker.BulkOverwriteCommandPermissionsAsync(guildid.Value, overwrites);
-								if (this.Client.Guilds.TryGetValue(guildid.Value, out var guild))
+								var perms = await PermissionWorker.BulkOverwriteCommandPermissionsAsync(guildId.Value, overwrites);
+								if (this.Client.Guilds.TryGetValue(guildId.Value, out var guild))
 								{
 									guild.InternalGuildApplicationCommandPermissions = new();
 									guild.InternalGuildApplicationCommandPermissions.AddRange(perms);
@@ -878,7 +878,7 @@ namespace DisCatSharp.ApplicationCommands
 						s_subGroupCommands.AddRange(subGroupCommands);
 						s_contextMenuCommands.AddRange(contextMenuCommands);
 
-						s_registeredCommands.Add(new KeyValuePair<ulong?, IReadOnlyList<DiscordApplicationCommand>>(guildid, commands.ToList()));
+						s_registeredCommands.Add(new KeyValuePair<ulong?, IReadOnlyList<DiscordApplicationCommand>>(guildId, commands.ToList()));
 
 						foreach (var command in commandMethods)
 						{
@@ -887,13 +887,13 @@ namespace DisCatSharp.ApplicationCommands
 
 						this.Client.Logger.Log(ApplicationCommandsLogLevel, $"Expected Count: {s_expectedCount}\nCurrent Count: {s_registrationCount}");
 
-						if (guildid.HasValue)
+						if (guildId.HasValue)
 						{
 							await this._guildApplicationCommandsRegistered.InvokeAsync(this, new GuildApplicationCommandsRegisteredEventArgs(Configuration?.ServiceProvider)
 							{
 								Handled = true,
-								GuildId = guildid.Value,
-								RegisteredCommands = GuildCommandsInternal.Any(c => c.Key == guildid.Value) ? GuildCommandsInternal.FirstOrDefault(c => c.Key == guildid.Value).Value : null
+								GuildId = guildId.Value,
+								RegisteredCommands = GuildCommandsInternal.Any(c => c.Key == guildId.Value) ? GuildCommandsInternal.FirstOrDefault(c => c.Key == guildId.Value).Value : null
 							});
 						}
 						else
@@ -1533,7 +1533,7 @@ namespace DisCatSharp.ApplicationCommands
 		/// <param name="type">The type.</param>
 		private static ApplicationCommandOptionType GetParameterType(Type type)
 		{
-			var parametertype = type == typeof(string)
+			var parameterType = type == typeof(string)
 				? ApplicationCommandOptionType.String
 				: type == typeof(long) || type == typeof(long?) || type == typeof(int) || type == typeof(int?)
 				? ApplicationCommandOptionType.Integer
@@ -1554,17 +1554,17 @@ namespace DisCatSharp.ApplicationCommands
 				: type.IsEnum
 				? ApplicationCommandOptionType.String
 				: throw new ArgumentException("Cannot convert type! Argument types must be string, int, long, bool, double, DiscordChannel, DiscordUser, DiscordRole, SnowflakeObject, DiscordAttachment or an Enum.");
-			return parametertype;
+			return parameterType;
 		}
 
 		/// <summary>
 		/// Gets the choice attributes from parameter.
 		/// </summary>
-		/// <param name="choiceattributes">The choice attributes.</param>
-		private static List<DiscordApplicationCommandOptionChoice> GetChoiceAttributesFromParameter(IEnumerable<ChoiceAttribute> choiceattributes) =>
-			!choiceattributes.Any()
+		/// <param name="choiceAttributes">The choice attributes.</param>
+		private static List<DiscordApplicationCommandOptionChoice> GetChoiceAttributesFromParameter(IEnumerable<ChoiceAttribute> choiceAttributes) =>
+			!choiceAttributes.Any()
 				? null
-				: choiceattributes.Select(att => new DiscordApplicationCommandOptionChoice(att.Name, att.Value)).ToList();
+				: choiceAttributes.Select(att => new DiscordApplicationCommandOptionChoice(att.Name, att.Value)).ToList();
 
 		/// <summary>
 		/// Parses the parameters.
@@ -1577,8 +1577,8 @@ namespace DisCatSharp.ApplicationCommands
 			foreach (var parameter in parameters)
 			{
 				//Gets the attribute
-				var optionattribute = parameter.GetCustomAttribute<OptionAttribute>();
-				if (optionattribute == null)
+				var optionAttribute = parameter.GetCustomAttribute<OptionAttribute>();
+				if (optionAttribute == null)
 					throw new ArgumentException("Arguments must have the Option attribute!");
 
 				var minimumValue = parameter.GetCustomAttribute<MinimumAttribute>()?.Value ?? null;
@@ -1586,14 +1586,14 @@ namespace DisCatSharp.ApplicationCommands
 
 
 				var autocompleteAttribute = parameter.GetCustomAttribute<AutocompleteAttribute>();
-				if (optionattribute.Autocomplete && autocompleteAttribute == null)
+				if (optionAttribute.Autocomplete && autocompleteAttribute == null)
 					throw new ArgumentException("Autocomplete options must have the Autocomplete attribute!");
-				if (!optionattribute.Autocomplete && autocompleteAttribute != null)
+				if (!optionAttribute.Autocomplete && autocompleteAttribute != null)
 					throw new ArgumentException("Setting an autocomplete provider requires the option to have autocomplete set to true!");
 
 				//Sets the type
 				var type = parameter.ParameterType;
-				var parametertype = GetParameterType(type);
+				var parameterType = GetParameterType(type);
 
 				//Handles choices
 				//From attributes
@@ -1612,7 +1612,7 @@ namespace DisCatSharp.ApplicationCommands
 
 				var channelTypes = parameter.GetCustomAttribute<ChannelTypesAttribute>()?.ChannelTypes ?? null;
 
-				options.Add(new DiscordApplicationCommandOption(optionattribute.Name, optionattribute.Description, parametertype, !parameter.IsOptional, choices, null, channelTypes, optionattribute.Autocomplete, minimumValue, maximumValue));
+				options.Add(new DiscordApplicationCommandOption(optionAttribute.Name, optionAttribute.Description, parameterType, !parameter.IsOptional, choices, null, channelTypes, optionAttribute.Autocomplete, minimumValue, maximumValue));
 			}
 
 			return options;

--- a/DisCatSharp.ApplicationCommands/Checks/ApplicationCommandEqualityChecks.cs
+++ b/DisCatSharp.ApplicationCommands/Checks/ApplicationCommandEqualityChecks.cs
@@ -38,7 +38,7 @@ namespace DisCatSharp.ApplicationCommands
 		/// Whether two application commands are equal.
 		/// </summary>
 		/// <param name="ac1">Source command.</param>
-		/// <param name="targetApplicationCommand">Command to check agains.</param>
+		/// <param name="targetApplicationCommand">Command to check against.</param>
 		internal static bool IsEqualTo(this DiscordApplicationCommand ac1, DiscordApplicationCommand targetApplicationCommand)
 		{
 			if (targetApplicationCommand is null || ac1 is null)

--- a/DisCatSharp.ApplicationCommands/Context/BaseContext.cs
+++ b/DisCatSharp.ApplicationCommands/Context/BaseContext.cs
@@ -31,7 +31,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace DisCatSharp.ApplicationCommands
 {
 	/// <summary>
-	/// Respresents a base context for application command contexts.
+	/// Represents a base context for application command contexts.
 	/// </summary>
 	public class BaseContext
 	{

--- a/DisCatSharp.ApplicationCommands/Context/ContextMenuContext.cs
+++ b/DisCatSharp.ApplicationCommands/Context/ContextMenuContext.cs
@@ -25,7 +25,7 @@ using DisCatSharp.Entities;
 namespace DisCatSharp.ApplicationCommands
 {
 	/// <summary>
-	/// Respresents a context for a context menu.
+	/// Represents a context for a context menu.
 	/// </summary>
 	public sealed class ContextMenuContext : BaseContext
 	{

--- a/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
+++ b/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
@@ -218,7 +218,7 @@ namespace DisCatSharp.ApplicationCommands
 				{
 					var commandAttribute = submethod.GetCustomAttribute<SlashCommandAttribute>();
 
-					//Gets the paramaters and accounts for InteractionContext
+					//Gets the parameters and accounts for InteractionContext
 					var parameters = submethod.GetParameters();
 					if (parameters.Length == 0 || parameters == null || !ReferenceEquals(parameters.First().ParameterType, typeof(InteractionContext)))
 						throw new ArgumentException($"The first argument must be an InteractionContext!");

--- a/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
+++ b/DisCatSharp.ApplicationCommands/Workers/ApplicationCommandWorker.cs
@@ -105,7 +105,7 @@ namespace DisCatSharp.ApplicationCommands
 
 			foreach (var method in methods)
 			{
-				var commandattribute = method.GetCustomAttribute<SlashCommandAttribute>();
+				var commandAttribute = method.GetCustomAttribute<SlashCommandAttribute>();
 
 				var parameters = method.GetParameters();
 				if (parameters.Length == 0 || parameters == null || !ReferenceEquals(parameters.FirstOrDefault()?.ParameterType, typeof(InteractionContext)))
@@ -113,17 +113,17 @@ namespace DisCatSharp.ApplicationCommands
 				parameters = parameters.Skip(1).ToArray();
 				var options = await ApplicationCommandsExtension.ParseParametersAsync(parameters, guildId);
 
-				commandMethods.Add(new CommandMethod { Method = method, Name = commandattribute.Name });
+				commandMethods.Add(new CommandMethod { Method = method, Name = commandAttribute.Name });
 
 				DiscordApplicationCommandLocalization nameLocalizations = null;
 				DiscordApplicationCommandLocalization descriptionLocalizations = null;
-				List<DiscordApplicationCommandOption> localizisedOptions = null;
+				List<DiscordApplicationCommandOption> localizedOptions = null;
 
-				var commandTranslation = translator?.Single(c => c.Name == commandattribute.Name && c.Type == ApplicationCommandType.ChatInput);
+				var commandTranslation = translator?.Single(c => c.Name == commandAttribute.Name && c.Type == ApplicationCommandType.ChatInput);
 
 				if (commandTranslation != null && commandTranslation.Options != null)
 				{
-					localizisedOptions = new List<DiscordApplicationCommandOption>(options.Count);
+					localizedOptions = new List<DiscordApplicationCommandOption>(options.Count);
 					foreach (var option in options)
 					{
 						var choices = option.Choices != null ? new List<DiscordApplicationCommandOptionChoice>(option.Choices.Count) : null;
@@ -135,7 +135,7 @@ namespace DisCatSharp.ApplicationCommands
 							}
 						}
 
-						localizisedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
+						localizedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
 							choices, option.Options, option.ChannelTypes, option.AutoComplete, option.MinimumValue, option.MaximumValue,
 							commandTranslation.Options.Single(o => o.Name == option.Name).NameTranslations, commandTranslation.Options.Single(o => o.Name == option.Name).DescriptionTranslations
 						));
@@ -145,7 +145,7 @@ namespace DisCatSharp.ApplicationCommands
 					descriptionLocalizations = commandTranslation.DescriptionTranslations;
 				}
 
-				var payload = new DiscordApplicationCommand(commandattribute.Name, commandattribute.Description, (localizisedOptions != null && localizisedOptions.Any() ? localizisedOptions : null) ?? (options != null && options.Any() ? options : null), commandattribute.DefaultPermission, ApplicationCommandType.ChatInput, nameLocalizations, descriptionLocalizations);
+				var payload = new DiscordApplicationCommand(commandAttribute.Name, commandAttribute.Description, (localizedOptions != null && localizedOptions.Any() ? localizedOptions : null) ?? (options != null && options.Any() ? options : null), commandAttribute.DefaultPermission, ApplicationCommandType.ChatInput, nameLocalizations, descriptionLocalizations);
 				commands.Add(payload);
 				commandTypeSources.Add(new KeyValuePair<Type, Type>(type, type));
 			}
@@ -184,12 +184,12 @@ namespace DisCatSharp.ApplicationCommands
 			List<object> singletonModules = new();
 
 			//Handles groups
-			foreach (var subclassinfo in types)
+			foreach (var subclassInfo in types)
 			{
 				//Gets the attribute and methods in the group
-				var groupAttribute = subclassinfo.GetCustomAttribute<SlashCommandGroupAttribute>();
-				var submethods = subclassinfo.DeclaredMethods.Where(x => x.GetCustomAttribute<SlashCommandAttribute>() != null).ToList();
-				var subclasses = subclassinfo.DeclaredNestedTypes.Where(x => x.GetCustomAttribute<SlashCommandGroupAttribute>() != null).ToList();
+				var groupAttribute = subclassInfo.GetCustomAttribute<SlashCommandGroupAttribute>();
+				var submethods = subclassInfo.DeclaredMethods.Where(x => x.GetCustomAttribute<SlashCommandAttribute>() != null).ToList();
+				var subclasses = subclassInfo.DeclaredNestedTypes.Where(x => x.GetCustomAttribute<SlashCommandGroupAttribute>() != null).ToList();
 				if (subclasses.Any() && submethods.Any())
 				{
 					throw new ArgumentException("Slash command groups cannot have both subcommands and subgroups!");
@@ -212,7 +212,7 @@ namespace DisCatSharp.ApplicationCommands
 				var payload = new DiscordApplicationCommand(groupAttribute.Name, groupAttribute.Description, defaultPermission: groupAttribute.DefaultPermission, nameLocalizations: nameLocalizations, descriptionLocalizations: descriptionLocalizations);
 				commandTypeSources.Add(new KeyValuePair<Type, Type>(type, type));
 
-				var commandmethods = new List<KeyValuePair<string, MethodInfo>>();
+				var commandMethods = new List<KeyValuePair<string, MethodInfo>>();
 				//Handles commands in the group
 				foreach (var submethod in submethods)
 				{
@@ -228,7 +228,7 @@ namespace DisCatSharp.ApplicationCommands
 
 					DiscordApplicationCommandLocalization subNameLocalizations = null;
 					DiscordApplicationCommandLocalization subDescriptionLocalizations = null;
-					List<DiscordApplicationCommandOption> localizisedOptions = null;
+					List<DiscordApplicationCommandOption> localizedOptions = null;
 
 					var commandTranslation = translator?.Single(c => c.Name == payload.Name);
 
@@ -238,7 +238,7 @@ namespace DisCatSharp.ApplicationCommands
 						var subCommandTranslation = commandTranslation.Commands.Single(sc => sc.Name == commandAttribute.Name);
 						if (subCommandTranslation.Options != null)
 						{
-							localizisedOptions = new List<DiscordApplicationCommandOption>(options.Count);
+							localizedOptions = new List<DiscordApplicationCommandOption>(options.Count);
 							foreach (var option in options)
 							{
 								var choices = option.Choices != null ? new List<DiscordApplicationCommandOptionChoice>(option.Choices.Count) : null;
@@ -250,7 +250,7 @@ namespace DisCatSharp.ApplicationCommands
 									}
 								}
 
-								localizisedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
+								localizedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
 									choices, option.Options, option.ChannelTypes, option.AutoComplete, option.MinimumValue, option.MaximumValue,
 									subCommandTranslation.Options.Single(o => o.Name == option.Name).NameTranslations, subCommandTranslation.Options.Single(o => o.Name == option.Name).DescriptionTranslations
 								));
@@ -263,20 +263,20 @@ namespace DisCatSharp.ApplicationCommands
 
 
 					//Creates the subcommand and adds it to the main command
-					var subpayload = new DiscordApplicationCommandOption(commandAttribute.Name, commandAttribute.Description, ApplicationCommandOptionType.SubCommand, null, null, localizisedOptions ?? options, nameLocalizations: subNameLocalizations, descriptionLocalizations: subDescriptionLocalizations);
+					var subpayload = new DiscordApplicationCommandOption(commandAttribute.Name, commandAttribute.Description, ApplicationCommandOptionType.SubCommand, null, null, localizedOptions ?? options, nameLocalizations: subNameLocalizations, descriptionLocalizations: subDescriptionLocalizations);
 					payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, nameLocalizations: payload.NameLocalizations, descriptionLocalizations: payload.DescriptionLocalizations);
-					commandTypeSources.Add(new KeyValuePair<Type, Type>(subclassinfo, type));
+					commandTypeSources.Add(new KeyValuePair<Type, Type>(subclassInfo, type));
 
 					//Adds it to the method lists
-					commandmethods.Add(new KeyValuePair<string, MethodInfo>(commandAttribute.Name, submethod));
-					groupCommands.Add(new GroupCommand { Name = groupAttribute.Name, Methods = commandmethods });
+					commandMethods.Add(new KeyValuePair<string, MethodInfo>(commandAttribute.Name, submethod));
+					groupCommands.Add(new GroupCommand { Name = groupAttribute.Name, Methods = commandMethods });
 				}
 
 				var command = new SubGroupCommand { Name = groupAttribute.Name };
 				//Handles subgroups
 				foreach (var subclass in subclasses)
 				{
-					var subGroupAttribute = subclass.GetCustomAttribute<SlashCommandGroupAttribute>();
+					var subgroupAttribute = subclass.GetCustomAttribute<SlashCommandGroupAttribute>();
 					var subsubmethods = subclass.DeclaredMethods.Where(x => x.GetCustomAttribute<SlashCommandAttribute>() != null);
 
 					var options = new List<DiscordApplicationCommandOption>();
@@ -293,7 +293,7 @@ namespace DisCatSharp.ApplicationCommands
 						if (commandTranslation != null && commandTranslation.SubGroups != null)
 						{
 
-							var subCommandTranslation = commandTranslation.SubGroups.Single(sc => sc.Name == subGroupAttribute.Name);
+							var subCommandTranslation = commandTranslation.SubGroups.Single(sc => sc.Name == subgroupAttribute.Name);
 
 							if (subCommandTranslation != null)
 							{
@@ -317,7 +317,7 @@ namespace DisCatSharp.ApplicationCommands
 
 						DiscordApplicationCommandLocalization subSubNameLocalizations = null;
 						DiscordApplicationCommandLocalization subSubDescriptionLocalizations = null;
-						List<DiscordApplicationCommandOption> localizisedOptions = null;
+						List<DiscordApplicationCommandOption> localizedOptions = null;
 
 						var commandTranslation = translator?.Single(c => c.Name == payload.Name);
 
@@ -327,7 +327,7 @@ namespace DisCatSharp.ApplicationCommands
 
 						if (subSubCommandTranslation != null && subSubCommandTranslation.Options != null)
 						{
-							localizisedOptions = new List<DiscordApplicationCommandOption>(suboptions.Count);
+							localizedOptions = new List<DiscordApplicationCommandOption>(suboptions.Count);
 							foreach (var option in suboptions)
 							{
 								var choices = option.Choices != null ? new List<DiscordApplicationCommandOptionChoice>(option.Choices.Count) : null;
@@ -339,7 +339,7 @@ namespace DisCatSharp.ApplicationCommands
 									}
 								}
 
-								localizisedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
+								localizedOptions.Add(new DiscordApplicationCommandOption(option.Name, option.Description, option.Type, option.Required,
 									choices, option.Options, option.ChannelTypes, option.AutoComplete, option.MinimumValue, option.MaximumValue,
 									subSubCommandTranslation.Options.Single(o => o.Name == option.Name).NameTranslations, subSubCommandTranslation.Options.Single(o => o.Name == option.Name).DescriptionTranslations
 								));
@@ -349,15 +349,15 @@ namespace DisCatSharp.ApplicationCommands
 							subSubDescriptionLocalizations = subSubCommandTranslation.DescriptionTranslations;
 						}
 
-						var subsubpayload = new DiscordApplicationCommandOption(commatt.Name, commatt.Description, ApplicationCommandOptionType.SubCommand, null, null, (localizisedOptions != null && localizisedOptions.Any() ? localizisedOptions : null) ?? (suboptions != null && suboptions.Any() ? suboptions : null), nameLocalizations: subSubNameLocalizations, descriptionLocalizations: subSubDescriptionLocalizations);
+						var subsubpayload = new DiscordApplicationCommandOption(commatt.Name, commatt.Description, ApplicationCommandOptionType.SubCommand, null, null, (localizedOptions != null && localizedOptions.Any() ? localizedOptions : null) ?? (suboptions != null && suboptions.Any() ? suboptions : null), nameLocalizations: subSubNameLocalizations, descriptionLocalizations: subSubDescriptionLocalizations);
 						options.Add(subsubpayload);
-						commandmethods.Add(new KeyValuePair<string, MethodInfo>(commatt.Name, subsubmethod));
+						commandMethods.Add(new KeyValuePair<string, MethodInfo>(commatt.Name, subsubmethod));
 						currentMethods.Add(new KeyValuePair<string, MethodInfo>(commatt.Name, subsubmethod));
 					}
 
 					//Adds the group to the command and method lists
-					var subpayload = new DiscordApplicationCommandOption(subGroupAttribute.Name, subGroupAttribute.Description, ApplicationCommandOptionType.SubCommandGroup, null, null, options, nameLocalizations: subNameLocalizations, descriptionLocalizations: subDescriptionLocalizations);
-					command.SubCommands.Add(new GroupCommand { Name = subGroupAttribute.Name, Methods = currentMethods });
+					var subpayload = new DiscordApplicationCommandOption(subgroupAttribute.Name, subgroupAttribute.Description, ApplicationCommandOptionType.SubCommandGroup, null, null, options, nameLocalizations: subNameLocalizations, descriptionLocalizations: subDescriptionLocalizations);
+					command.SubCommands.Add(new GroupCommand { Name = subgroupAttribute.Name, Methods = currentMethods });
 					payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, nameLocalizations: payload.NameLocalizations, descriptionLocalizations: payload.DescriptionLocalizations);
 					commandTypeSources.Add(new KeyValuePair<Type, Type>(subclass, type));
 
@@ -371,9 +371,9 @@ namespace DisCatSharp.ApplicationCommands
 				commands.Add(payload);
 
 				//Accounts for lifespans
-				if (subclassinfo.GetCustomAttribute<ApplicationCommandModuleLifespanAttribute>() != null && subclassinfo.GetCustomAttribute<ApplicationCommandModuleLifespanAttribute>().Lifespan == ApplicationCommandModuleLifespan.Singleton)
+				if (subclassInfo.GetCustomAttribute<ApplicationCommandModuleLifespanAttribute>() != null && subclassInfo.GetCustomAttribute<ApplicationCommandModuleLifespanAttribute>().Lifespan == ApplicationCommandModuleLifespan.Singleton)
 				{
-					singletonModules.Add(ApplicationCommandsExtension.CreateInstance(subclassinfo, ApplicationCommandsExtension.Configuration?.ServiceProvider));
+					singletonModules.Add(ApplicationCommandsExtension.CreateInstance(subclassInfo, ApplicationCommandsExtension.Configuration?.ServiceProvider));
 				}
 			}
 

--- a/DisCatSharp.ApplicationCommands/Workers/PermissionWorker.cs
+++ b/DisCatSharp.ApplicationCommands/Workers/PermissionWorker.cs
@@ -40,14 +40,14 @@ namespace DisCatSharp.ApplicationCommands
 		/// Updates the application command permissions.
 		/// </summary>
 		/// <param name="types">The types.</param>
-		/// <param name="guildid">The optional guild id.</param>
+		/// <param name="guildId">The optional guild id.</param>
 		/// <param name="commandId">The command id.</param>
 		/// <param name="commandName">The command name.</param>
 		/// <param name="commandDeclaringType">The declaring command type.</param>
 		/// <param name="commandRootType">The root command type.</param>
-		internal static async Task UpdateCommandPermissionAsync(IEnumerable<ApplicationCommandsModuleConfiguration> types, ulong? guildid, ulong commandId, string commandName, Type commandDeclaringType, Type commandRootType)
+		internal static async Task UpdateCommandPermissionAsync(IEnumerable<ApplicationCommandsModuleConfiguration> types, ulong? guildId, ulong commandId, string commandName, Type commandDeclaringType, Type commandRootType)
 		{
-			if (!guildid.HasValue)
+			if (!guildId.HasValue)
 			{
 				ApplicationCommandsExtension.ClientInternal.Logger.LogTrace("You can't set global permissions till yet. See https://discord.com/developers/docs/interactions/application-commands#permissions");
 				return;
@@ -60,9 +60,9 @@ namespace DisCatSharp.ApplicationCommands
 			if (ctx.Permissions.Count == 0)
 				return;
 
-			ApplicationCommandsExtension.ClientInternal.Logger.Log(ApplicationCommandsExtension.ApplicationCommandsLogLevel, $"[AC Perms] Command {commandName} permission update on {guildid.Value}");
+			ApplicationCommandsExtension.ClientInternal.Logger.Log(ApplicationCommandsExtension.ApplicationCommandsLogLevel, $"[AC Perms] Command {commandName} permission update on {guildId.Value}");
 
-			await ApplicationCommandsExtension.ClientInternal.OverwriteGuildApplicationCommandPermissionsAsync(guildid.Value, commandId, ctx.Permissions);
+			await ApplicationCommandsExtension.ClientInternal.OverwriteGuildApplicationCommandPermissionsAsync(guildId.Value, commandId, ctx.Permissions);
 		}
 
 		/// <summary>

--- a/DisCatSharp.ApplicationCommands/Workers/RegistrationWorker.cs
+++ b/DisCatSharp.ApplicationCommands/Workers/RegistrationWorker.cs
@@ -187,7 +187,7 @@ namespace DisCatSharp.ApplicationCommands
 		/// <param name="guildId">The target guild id.</param>
 		/// <param name="commands">The command list.</param>
 		/// <returns>A list of registered commands.</returns>
-		internal static async Task<List<DiscordApplicationCommand>> RegisterGuilldCommandsAsync(ulong guildId, List<DiscordApplicationCommand> commands)
+		internal static async Task<List<DiscordApplicationCommand>> RegisterGuildCommandsAsync(ulong guildId, List<DiscordApplicationCommand> commands)
 		{
 			var (changedCommands, unchangedCommands) = BuildGuildOverwriteList(guildId, commands);
 			var guildCommandsCreateList = BuildGuildCreateList(guildId, commands);

--- a/DisCatSharp.CommandsNext/Attributes/CooldownAttribute.cs
+++ b/DisCatSharp.CommandsNext/Attributes/CooldownAttribute.cs
@@ -243,7 +243,7 @@ namespace DisCatSharp.CommandsNext.Attributes
 		/// <summary>
 		/// Decrements the remaining use counter.
 		/// </summary>
-		/// <returns>Whether decrement succeded or not.</returns>
+		/// <returns>Whether decrement succeeded or not.</returns>
 		internal async Task<bool> DecrementUseAsync()
 		{
 			await this._usageSemaphore.WaitAsync().ConfigureAwait(false);

--- a/DisCatSharp.CommandsNext/Entities/CommandGroup.cs
+++ b/DisCatSharp.CommandsNext/Entities/CommandGroup.cs
@@ -56,8 +56,8 @@ namespace DisCatSharp.CommandsNext
 		/// <returns>Command's execution results.</returns>
 		public override async Task<CommandResult> ExecuteAsync(CommandContext ctx)
 		{
-			var findpos = 0;
-			var cn = CommandsNextUtilities.ExtractNextArgument(ctx.RawArgumentString, ref findpos);
+			var findPos = 0;
+			var cn = CommandsNextUtilities.ExtractNextArgument(ctx.RawArgumentString, ref findPos);
 
 			if (cn != null)
 			{
@@ -73,7 +73,7 @@ namespace DisCatSharp.CommandsNext
 						Message = ctx.Message,
 						Command = cmd,
 						Config = ctx.Config,
-						RawArgumentString = ctx.RawArgumentString[findpos..],
+						RawArgumentString = ctx.RawArgumentString[findPos..],
 						Prefix = ctx.Prefix,
 						CommandsNext = ctx.CommandsNext,
 						Services = ctx.Services

--- a/DisCatSharp.Common/Types/IMemoryBuffer.cs
+++ b/DisCatSharp.Common/Types/IMemoryBuffer.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the DisCatSharp project, based off DSharpPlus.
+// This file is part of the DisCatSharp project, based off DSharpPlus.
 //
 // Copyright (c) 2021-2022 AITSYS
 //
@@ -37,7 +37,7 @@ namespace DisCatSharp.Common.Types
 		ulong Capacity { get; }
 
 		/// <summary>
-		/// Gets the amount of bytes currently written to the buffer. This number is never greather than <see cref="Capacity"/>.
+		/// Gets the amount of bytes currently written to the buffer. This number is never greater than <see cref="Capacity"/>.
 		/// </summary>
 		ulong Length { get; }
 

--- a/DisCatSharp.Common/Types/Optional.cs
+++ b/DisCatSharp.Common/Types/Optional.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the DisCatSharp project, based off DSharpPlus.
+// This file is part of the DisCatSharp project, based off DSharpPlus.
 //
 // Copyright (c) 2021-2022 AITSYS
 //
@@ -110,7 +110,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Checks whether this proerty's value is equal to another value.
+		/// Checks whether this property's value is equal to another value.
 		/// </summary>
 		/// <param name="other">Value to compare this property's value against.</param>
 		/// <returns>Whether the supplied value is equal to the value of this property.</returns>

--- a/DisCatSharp.Common/Types/SecureRandom.cs
+++ b/DisCatSharp.Common/Types/SecureRandom.cs
@@ -69,7 +69,7 @@ namespace DisCatSharp.Common
 		/// <summary>
 		/// Fills a supplied memory region with random bytes.
 		/// </summary>
-		/// <param name="buffer">Memmory region to fill with random bytes.</param>
+		/// <param name="buffer">Memory region to fill with random bytes.</param>
 		public void GetBytes(Span<byte> buffer)
 		{
 			var buff = ArrayPool<byte>.Shared.Rent(buffer.Length);
@@ -88,7 +88,7 @@ namespace DisCatSharp.Common
 		/// <summary>
 		/// Fills a supplied memory region with random nonzero bytes.
 		/// </summary>
-		/// <param name="buffer">Memmory region to fill with random nonzero bytes.</param>
+		/// <param name="buffer">Memory region to fill with random nonzero bytes.</param>
 		public void GetNonZeroBytes(Span<byte> buffer)
 		{
 			var buff = ArrayPool<byte>.Shared.Rent(buffer.Length);

--- a/DisCatSharp.Common/Utilities/AsyncEvent/AsyncEvent.cs
+++ b/DisCatSharp.Common/Utilities/AsyncEvent/AsyncEvent.cs
@@ -56,7 +56,7 @@ namespace DisCatSharp.Common.Utilities
 		where TArgs : AsyncEventArgs
 	{
 		/// <summary>
-		/// Gets the maximum alloted execution time for all handlers. Any event which causes the handler to time out 
+		/// Gets the maximum allotted execution time for all handlers. Any event which causes the handler to time out 
 		/// will raise a non-fatal <see cref="AsyncEventTimeoutException{TSender, TArgs}"/>.
 		/// </summary>
 		public TimeSpan MaximumExecutionTime { get; }

--- a/DisCatSharp.Common/Utilities/AsyncEvent/AsyncEventExceptionMode.cs
+++ b/DisCatSharp.Common/Utilities/AsyncEvent/AsyncEventExceptionMode.cs
@@ -70,7 +70,7 @@ namespace DisCatSharp.Common.Utilities
 
 		/// <summary>
 		/// Defines that all exceptions should be thrown and handled by the specified exception handler. This is 
-		/// equivalent to combinind <see cref="HandleAll"/> and <see cref="ThrowAll"/> flags.
+		/// equivalent to combining <see cref="HandleAll"/> and <see cref="ThrowAll"/> flags.
 		/// </summary>
 		ThrowAllHandleAll = ThrowAll | HandleAll,
 

--- a/DisCatSharp.Common/Utilities/AsyncExecutor.cs
+++ b/DisCatSharp.Common/Utilities/AsyncExecutor.cs
@@ -146,7 +146,7 @@ namespace DisCatSharp.Common.Utilities
 			public AutoResetEvent Lock { get; }
 
 			/// <summary>
-			/// Gets the exception that occured during task's execution, if any.
+			/// Gets the exception that occurred during task's execution, if any.
 			/// </summary>
 			public Exception Exception { get; set; }
 

--- a/DisCatSharp.Common/Utilities/Extensions.cs
+++ b/DisCatSharp.Common/Utilities/Extensions.cs
@@ -59,7 +59,7 @@ namespace DisCatSharp.Common
 		/// Calculates the length of string representation of given number in base 10 (including sign, if present).
 		/// </summary>
 		/// <param name="num">Number to calculate the length of.</param>
-		/// <returns>Calculated nuembr length.</returns>
+		/// <returns>Calculated number length.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int CalculateLength(this byte num)
 			=> num == 0 ? 1 : (int)Math.Floor(Math.Log10(num)) + 1;
@@ -77,7 +77,7 @@ namespace DisCatSharp.Common
 		/// Calculates the length of string representation of given number in base 10 (including sign, if present).
 		/// </summary>
 		/// <param name="num">Number to calculate the length of.</param>
-		/// <returns>Calculated nuembr length.</returns>
+		/// <returns>Calculated number length.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int CalculateLength(this ushort num)
 			=> num == 0 ? 1 : (int)Math.Floor(Math.Log10(num)) + 1;
@@ -95,7 +95,7 @@ namespace DisCatSharp.Common
 		/// Calculates the length of string representation of given number in base 10 (including sign, if present).
 		/// </summary>
 		/// <param name="num">Number to calculate the length of.</param>
-		/// <returns>Calculated nuembr length.</returns>
+		/// <returns>Calculated number length.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int CalculateLength(this uint num)
 			=> num == 0 ? 1 : (int)Math.Floor(Math.Log10(num)) + 1;
@@ -113,13 +113,13 @@ namespace DisCatSharp.Common
 		/// Calculates the length of string representation of given number in base 10 (including sign, if present).
 		/// </summary>
 		/// <param name="num">Number to calculate the length of.</param>
-		/// <returns>Calculated nuembr length.</returns>
+		/// <returns>Calculated number length.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int CalculateLength(this ulong num)
 			=> num == 0 ? 1 : (int)Math.Floor(Math.Log10(num)) + 1;
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -140,7 +140,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -161,7 +161,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -182,7 +182,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -203,7 +203,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -224,7 +224,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -245,7 +245,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -266,7 +266,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -287,7 +287,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>
@@ -304,7 +304,7 @@ namespace DisCatSharp.Common
 		}
 
 		/// <summary>
-		/// Tests wheter given value is in supplied range, optionally allowing it to be an exclusive check.
+		/// Tests whether given value is in supplied range, optionally allowing it to be an exclusive check.
 		/// </summary>
 		/// <param name="num">Number to test.</param>
 		/// <param name="min">Lower bound of the range.</param>

--- a/DisCatSharp.Common/Utilities/ReflectionUtilities.cs
+++ b/DisCatSharp.Common/Utilities/ReflectionUtilities.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the DisCatSharp project, based off DSharpPlus.
+// This file is part of the DisCatSharp project, based off DSharpPlus.
 //
 // Copyright (c) 2021-2022 AITSYS
 //
@@ -47,13 +47,13 @@ namespace DisCatSharp.Common.Utilities
 
 		/// <summary>
 		/// <para>Creates an empty, uninitialized instance of type <typeparamref name="T"/>.</para>
-		/// <para>This method will not call the constructor for type <typeparamref name="T"/>. As such, the object might not be proerly initialized.</para>
+		/// <para>This method will not call the constructor for type <typeparamref name="T"/>. As such, the object might not be properly initialized.</para>
 		/// </summary>
 		/// <remarks>
 		/// This method is intended for reflection use only.
 		/// </remarks>
 		/// <typeparam name="T">Type of the object to instantiate.</typeparam>
-		/// <returns>Empty, uninitalized object of specified type.</returns>
+		/// <returns>Empty, uninitialized object of specified type.</returns>
 		public static T CreateEmpty<T>()
 			=> (T)FormatterServices.GetUninitializedObject(typeof(T));
 

--- a/DisCatSharp.Configuration.Tests/ConfigurationExtensionTests.cs
+++ b/DisCatSharp.Configuration.Tests/ConfigurationExtensionTests.cs
@@ -172,7 +172,7 @@ namespace DisCatSharp.Configuration.Tests
 		}
 
 		[Fact]
-		public void TestExtractDiscordConfig_Haphzard()
+		public void TestExtractDiscordConfig_Haphazard()
 		{
 			var source = this.DiscordHaphazardConfig();
 

--- a/DisCatSharp.Configuration.Tests/GlobalSuppressions.cs
+++ b/DisCatSharp.Configuration.Tests/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the DisCatSharp project, based off DSharpPlus.
+// This file is part of the DisCatSharp project, based off DSharpPlus.
 //
 // Copyright (c) 2021-2022 AITSYS
 //
@@ -59,7 +59,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractConfig_V3_Change")]
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractConfig_V3_Default")]
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractDiscordConfig_Default")]
-[assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractDiscordConfig_Haphzard")]
+[assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractDiscordConfig_Haphazard")]
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestExtractDiscordConfig_Intents")]
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestHasSectionNoSuffix")]
 [assembly: SuppressMessage("DocumentationHeader", "MethodDocumentationHeader:The method must have a documentation header.", Justification = "<Pending>", Scope = "member", Target = "~M:DisCatSharp.Configuration.Tests.ConfigurationExtensionTests.TestHasSectionWithSuffix")]

--- a/DisCatSharp.Interactivity/EventHandling/Components/ComponentEventWaiter.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Components/ComponentEventWaiter.cs
@@ -62,7 +62,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		}
 
 		/// <summary>
-		/// Waits for a specified <see cref="ComponentMatchRequest"/>'s predicate to be fufilled.
+		/// Waits for a specified <see cref="ComponentMatchRequest"/>'s predicate to be fulfilled.
 		/// </summary>
 		/// <param name="request">The request to wait for.</param>
 		/// <returns>The returned args, or null if it timed out.</returns>

--- a/DisCatSharp.Interactivity/EventHandling/Components/ModalEventWaiter.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Components/ModalEventWaiter.cs
@@ -60,7 +60,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		}
 
 		/// <summary>
-		/// Waits for a specified <see cref="ModalMatchRequest"/>'s predicate to be fufilled.
+		/// Waits for a specified <see cref="ModalMatchRequest"/>'s predicate to be fulfilled.
 		/// </summary>
 		/// <param name="request">The request to wait for.</param>
 		/// <returns>The returned args, or null if it timed out.</returns>

--- a/DisCatSharp.Interactivity/EventHandling/EventWaiter.cs
+++ b/DisCatSharp.Interactivity/EventHandling/EventWaiter.cs
@@ -45,8 +45,8 @@ namespace DisCatSharp.Interactivity.EventHandling
 		DiscordClient _client;
 		AsyncEvent<DiscordClient, T> _event;
 		AsyncEventHandler<DiscordClient, T> _handler;
-		ConcurrentHashSet<MatchRequest<T>> _matchrequests;
-		ConcurrentHashSet<CollectRequest<T>> _collectrequests;
+		ConcurrentHashSet<MatchRequest<T>> _matchRequests;
+		ConcurrentHashSet<CollectRequest<T>> _collectRequests;
 		bool _disposed;
 
 		/// <summary>
@@ -58,8 +58,8 @@ namespace DisCatSharp.Interactivity.EventHandling
 			this._client = client;
 			var tinfo = this._client.GetType().GetTypeInfo();
 			var handler = tinfo.DeclaredFields.First(x => x.FieldType == typeof(AsyncEvent<DiscordClient, T>));
-			this._matchrequests = new ConcurrentHashSet<MatchRequest<T>>();
-			this._collectrequests = new ConcurrentHashSet<CollectRequest<T>>();
+			this._matchRequests = new ConcurrentHashSet<MatchRequest<T>>();
+			this._collectRequests = new ConcurrentHashSet<CollectRequest<T>>();
 			this._event = (AsyncEvent<DiscordClient, T>)handler.GetValue(this._client);
 			this._handler = new AsyncEventHandler<DiscordClient, T>(this.HandleEvent);
 			this._event.Register(this._handler);
@@ -73,7 +73,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		public async Task<T> WaitForMatchAsync(MatchRequest<T> request)
 		{
 			T result = null;
-			this._matchrequests.Add(request);
+			this._matchRequests.Add(request);
 			try
 			{
 				result = await request.Tcs.Task.ConfigureAwait(false);
@@ -85,7 +85,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 			finally
 			{
 				request.Dispose();
-				this._matchrequests.TryRemove(request);
+				this._matchRequests.TryRemove(request);
 			}
 			return result;
 		}
@@ -97,7 +97,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		public async Task<ReadOnlyCollection<T>> CollectMatchesAsync(CollectRequest<T> request)
 		{
 			ReadOnlyCollection<T> result = null;
-			this._collectrequests.Add(request);
+			this._collectRequests.Add(request);
 			try
 			{
 				await request.Tcs.Task.ConfigureAwait(false);
@@ -110,7 +110,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 			{
 				result = new ReadOnlyCollection<T>(new HashSet<T>(request.Collected).ToList());
 				request.Dispose();
-				this._collectrequests.TryRemove(request);
+				this._collectRequests.TryRemove(request);
 			}
 			return result;
 		}
@@ -119,24 +119,24 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the event.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The event args.</param>
-		private Task HandleEvent(DiscordClient client, T eventargs)
+		/// <param name="eventArgs">The event's arguments.</param>
+		private Task HandleEvent(DiscordClient client, T eventArgs)
 		{
 			if (!this._disposed)
 			{
-				foreach (var req in this._matchrequests)
+				foreach (var req in this._matchRequests)
 				{
-					if (req.Predicate(eventargs))
+					if (req.Predicate(eventArgs))
 					{
-						req.Tcs.TrySetResult(eventargs);
+						req.Tcs.TrySetResult(eventArgs);
 					}
 				}
 
-				foreach (var req in this._collectrequests)
+				foreach (var req in this._collectRequests)
 				{
-					if (req.Predicate(eventargs))
+					if (req.Predicate(eventArgs))
 					{
-						req.Collected.Add(eventargs);
+						req.Collected.Add(eventArgs);
 					}
 				}
 			}
@@ -162,13 +162,13 @@ namespace DisCatSharp.Interactivity.EventHandling
 			this._handler = null;
 			this._client = null;
 
-			if (this._matchrequests != null)
-				this._matchrequests.Clear();
-			if (this._collectrequests != null)
-				this._collectrequests.Clear();
+			if (this._matchRequests != null)
+				this._matchRequests.Clear();
+			if (this._collectRequests != null)
+				this._collectRequests.Clear();
 
-			this._matchrequests = null;
-			this._collectrequests = null;
+			this._matchRequests = null;
+			this._collectRequests = null;
 		}
 	}
 }

--- a/DisCatSharp.Interactivity/EventHandling/EventWaiter.cs
+++ b/DisCatSharp.Interactivity/EventHandling/EventWaiter.cs
@@ -36,7 +36,7 @@ using Microsoft.Extensions.Logging;
 namespace DisCatSharp.Interactivity.EventHandling
 {
 	/// <summary>
-	/// Eventwaiter is a class that serves as a layer between the InteractivityExtension
+	/// EventWaiter is a class that serves as a layer between the InteractivityExtension
 	/// and the DiscordClient to listen to an event and check for matches to a predicate.
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
@@ -50,7 +50,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		bool _disposed;
 
 		/// <summary>
-		/// Creates a new Eventwaiter object.
+		/// Creates a new EventWaiter object.
 		/// </summary>
 		/// <param name="client">Your DiscordClient</param>
 		public EventWaiter(DiscordClient client)

--- a/DisCatSharp.Interactivity/EventHandling/Paginator.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Paginator.cs
@@ -90,8 +90,8 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction add.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
-		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+		/// <param name="eventArgs">The event's arguments.</param>
+		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventArgs)
 		{
 			if (this._requests.Count == 0)
 				return Task.CompletedTask;
@@ -104,39 +104,39 @@ namespace DisCatSharp.Interactivity.EventHandling
 					var msg = await req.GetMessageAsync().ConfigureAwait(false);
 					var usr = await req.GetUserAsync().ConfigureAwait(false);
 
-					if (msg.Id == eventargs.Message.Id)
+					if (msg.Id == eventArgs.Message.Id)
 					{
-						if (eventargs.User.Id == usr.Id)
+						if (eventArgs.User.Id == usr.Id)
 						{
 							if (req.PageCount > 1 &&
-								(eventargs.Emoji == emojis.Left ||
-								 eventargs.Emoji == emojis.SkipLeft ||
-								 eventargs.Emoji == emojis.Right ||
-								 eventargs.Emoji == emojis.SkipRight ||
-								 eventargs.Emoji == emojis.Stop))
+								(eventArgs.Emoji == emojis.Left ||
+								 eventArgs.Emoji == emojis.SkipLeft ||
+								 eventArgs.Emoji == emojis.Right ||
+								 eventArgs.Emoji == emojis.SkipRight ||
+								 eventArgs.Emoji == emojis.Stop))
 							{
-								await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+								await this.PaginateAsync(req, eventArgs.Emoji).ConfigureAwait(false);
 							}
-							else if (eventargs.Emoji == emojis.Stop &&
+							else if (eventArgs.Emoji == emojis.Stop &&
 									 req is PaginationRequest paginationRequest &&
 									 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
 							{
-								await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+								await this.PaginateAsync(req, eventArgs.Emoji).ConfigureAwait(false);
 							}
 							else
 							{
-								await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+								await msg.DeleteReactionAsync(eventArgs.Emoji, eventArgs.User).ConfigureAwait(false);
 							}
 						}
-						else if (eventargs.User.Id != this._client.CurrentUser.Id)
+						else if (eventArgs.User.Id != this._client.CurrentUser.Id)
 						{
-							if (eventargs.Emoji != emojis.Left &&
-							   eventargs.Emoji != emojis.SkipLeft &&
-							   eventargs.Emoji != emojis.Right &&
-							   eventargs.Emoji != emojis.SkipRight &&
-							   eventargs.Emoji != emojis.Stop)
+							if (eventArgs.Emoji != emojis.Left &&
+							   eventArgs.Emoji != emojis.SkipLeft &&
+							   eventArgs.Emoji != emojis.Right &&
+							   eventArgs.Emoji != emojis.SkipRight &&
+							   eventArgs.Emoji != emojis.Stop)
 							{
-								await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+								await msg.DeleteReactionAsync(eventArgs.Emoji, eventArgs.User).ConfigureAwait(false);
 							}
 						}
 					}
@@ -149,8 +149,8 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction remove.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
-		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
+		/// <param name="eventArgs">The event's arguments.</param>
+		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventArgs)
 		{
 			if (this._requests.Count == 0)
 				return Task.CompletedTask;
@@ -163,24 +163,24 @@ namespace DisCatSharp.Interactivity.EventHandling
 					var msg = await req.GetMessageAsync().ConfigureAwait(false);
 					var usr = await req.GetUserAsync().ConfigureAwait(false);
 
-					if (msg.Id == eventargs.Message.Id)
+					if (msg.Id == eventArgs.Message.Id)
 					{
-						if (eventargs.User.Id == usr.Id)
+						if (eventArgs.User.Id == usr.Id)
 						{
 							if (req.PageCount > 1 &&
-								(eventargs.Emoji == emojis.Left ||
-								 eventargs.Emoji == emojis.SkipLeft ||
-								 eventargs.Emoji == emojis.Right ||
-								 eventargs.Emoji == emojis.SkipRight ||
-								 eventargs.Emoji == emojis.Stop))
+								(eventArgs.Emoji == emojis.Left ||
+								 eventArgs.Emoji == emojis.SkipLeft ||
+								 eventArgs.Emoji == emojis.Right ||
+								 eventArgs.Emoji == emojis.SkipRight ||
+								 eventArgs.Emoji == emojis.Stop))
 							{
-								await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+								await this.PaginateAsync(req, eventArgs.Emoji).ConfigureAwait(false);
 							}
-							else if (eventargs.Emoji == emojis.Stop &&
+							else if (eventArgs.Emoji == emojis.Stop &&
 									 req is PaginationRequest paginationRequest &&
 									 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
 							{
-								await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+								await this.PaginateAsync(req, eventArgs.Emoji).ConfigureAwait(false);
 							}
 						}
 					}
@@ -194,8 +194,8 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction clear.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
-		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+		/// <param name="eventArgs">The eventArgs.</param>
+		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventArgs)
 		{
 			if (this._requests.Count == 0)
 				return Task.CompletedTask;
@@ -206,7 +206,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 				{
 					var msg = await req.GetMessageAsync().ConfigureAwait(false);
 
-					if (msg.Id == eventargs.Message.Id)
+					if (msg.Id == eventArgs.Message.Id)
 					{
 						await this.ResetReactionsAsync(req).ConfigureAwait(false);
 					}

--- a/DisCatSharp.Interactivity/EventHandling/Paginator.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Paginator.cs
@@ -42,7 +42,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		ConcurrentHashSet<IPaginationRequest> _requests;
 
 		/// <summary>
-		/// Creates a new Eventwaiter object.
+		/// Creates a new EventWaiter object.
 		/// </summary>
 		/// <param name="client">Discord client</param>
 		public Paginator(DiscordClient client)

--- a/DisCatSharp.Interactivity/EventHandling/Poller.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Poller.cs
@@ -86,9 +86,9 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction add.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventArgs)
 		{
 			if (this._requests.Count == 0)
 				return Task.CompletedTask;
@@ -98,18 +98,18 @@ namespace DisCatSharp.Interactivity.EventHandling
 				foreach (var req in this._requests)
 				{
 					// match message
-					if (req.Message.Id == eventargs.Message.Id && req.Message.ChannelId == eventargs.Channel.Id)
+					if (req.Message.Id == eventArgs.Message.Id && req.Message.ChannelId == eventArgs.Channel.Id)
 					{
-						if (req.Emojis.Contains(eventargs.Emoji) && !req.Collected.Any(x => x.Voted.Contains(eventargs.User)))
+						if (req.Emojis.Contains(eventArgs.Emoji) && !req.Collected.Any(x => x.Voted.Contains(eventArgs.User)))
 						{
-							if (eventargs.User.Id != this._client.CurrentUser.Id)
-								req.AddReaction(eventargs.Emoji, eventargs.User);
+							if (eventArgs.User.Id != this._client.CurrentUser.Id)
+								req.AddReaction(eventArgs.Emoji, eventArgs.User);
 						}
 						else
 						{
-							var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id).ConfigureAwait(false);
-							if (eventargs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
-								await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+							var member = await eventArgs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id).ConfigureAwait(false);
+							if (eventArgs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
+								await eventArgs.Message.DeleteReactionAsync(eventArgs.Emoji, eventArgs.User).ConfigureAwait(false);
 						}
 					}
 				}
@@ -121,17 +121,17 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction remove.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
+		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventArgs)
 		{
 			foreach (var req in this._requests)
 			{
 				// match message
-				if (req.Message.Id == eventargs.Message.Id && req.Message.ChannelId == eventargs.Channel.Id)
+				if (req.Message.Id == eventArgs.Message.Id && req.Message.ChannelId == eventArgs.Channel.Id)
 				{
-					if (eventargs.User.Id != this._client.CurrentUser.Id)
-						req.RemoveReaction(eventargs.Emoji, eventargs.User);
+					if (eventArgs.User.Id != this._client.CurrentUser.Id)
+						req.RemoveReaction(eventArgs.Emoji, eventArgs.User);
 				}
 			}
 			return Task.CompletedTask;
@@ -141,14 +141,14 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction clear.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventArgs)
 		{
 			foreach (var req in this._requests)
 			{
 				// match message
-				if (req.Message.Id == eventargs.Message.Id && req.Message.ChannelId == eventargs.Channel.Id)
+				if (req.Message.Id == eventArgs.Message.Id && req.Message.ChannelId == eventArgs.Channel.Id)
 				{
 					req.ClearCollected();
 				}

--- a/DisCatSharp.Interactivity/EventHandling/Poller.cs
+++ b/DisCatSharp.Interactivity/EventHandling/Poller.cs
@@ -43,7 +43,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		ConcurrentHashSet<PollRequest> _requests;
 
 		/// <summary>
-		/// Creates a new Eventwaiter object.
+		/// Creates a new EventWaiter object.
 		/// </summary>
 		/// <param name="client">Your DiscordClient</param>
 		public Poller(DiscordClient client)

--- a/DisCatSharp.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DisCatSharp.Interactivity/EventHandling/ReactionCollector.cs
@@ -39,7 +39,7 @@ using Microsoft.Extensions.Logging;
 namespace DisCatSharp.Interactivity.EventHandling
 {
 	/// <summary>
-	/// Eventwaiter is a class that serves as a layer between the InteractivityExtension
+	/// EventWaiter is a class that serves as a layer between the InteractivityExtension
 	/// and the DiscordClient to listen to an event and check for matches to a predicate.
 	/// </summary>
 	internal class ReactionCollector : IDisposable
@@ -58,7 +58,7 @@ namespace DisCatSharp.Interactivity.EventHandling
 		ConcurrentHashSet<ReactionCollectRequest> _requests;
 
 		/// <summary>
-		/// Creates a new Eventwaiter object.
+		/// Creates a new EventWaiter object.
 		/// </summary>
 		/// <param name="client">Your DiscordClient</param>
 		public ReactionCollector(DiscordClient client)

--- a/DisCatSharp.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DisCatSharp.Interactivity/EventHandling/ReactionCollector.cs
@@ -119,28 +119,28 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction add.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+		private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventArgs)
 		{
 			// foreach request add
 			foreach (var req in this._requests)
 			{
-				if (req.Message.Id == eventargs.Message.Id)
+				if (req.Message.Id == eventArgs.Message.Id)
 				{
-					if (req.Collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id)))
+					if (req.Collected.Any(x => x.Emoji == eventArgs.Emoji && x.Users.Any(y => y.Id == eventArgs.User.Id)))
 					{
-						var reaction = req.Collected.First(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id));
+						var reaction = req.Collected.First(x => x.Emoji == eventArgs.Emoji && x.Users.Any(y => y.Id == eventArgs.User.Id));
 						req.Collected.TryRemove(reaction);
-						reaction.Users.Add(eventargs.User);
+						reaction.Users.Add(eventArgs.User);
 						req.Collected.Add(reaction);
 					}
 					else
 					{
 						req.Collected.Add(new Reaction()
 						{
-							Emoji = eventargs.Emoji,
-							Users = new ConcurrentHashSet<DiscordUser>() { eventargs.User }
+							Emoji = eventArgs.Emoji,
+							Users = new ConcurrentHashSet<DiscordUser>() { eventArgs.User }
 						});
 					}
 				}
@@ -152,20 +152,20 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction remove.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
+		private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventArgs)
 		{
 			// foreach request remove
 			foreach (var req in this._requests)
 			{
-				if (req.Message.Id == eventargs.Message.Id)
+				if (req.Message.Id == eventArgs.Message.Id)
 				{
-					if (req.Collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id)))
+					if (req.Collected.Any(x => x.Emoji == eventArgs.Emoji && x.Users.Any(y => y.Id == eventArgs.User.Id)))
 					{
-						var reaction = req.Collected.First(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id));
+						var reaction = req.Collected.First(x => x.Emoji == eventArgs.Emoji && x.Users.Any(y => y.Id == eventArgs.User.Id));
 						req.Collected.TryRemove(reaction);
-						reaction.Users.TryRemove(eventargs.User);
+						reaction.Users.TryRemove(eventArgs.User);
 						if (reaction.Users.Count > 0)
 							req.Collected.Add(reaction);
 					}
@@ -178,14 +178,14 @@ namespace DisCatSharp.Interactivity.EventHandling
 		/// Handles the reaction clear.
 		/// </summary>
 		/// <param name="client">The client.</param>
-		/// <param name="eventargs">The eventargs.</param>
+		/// <param name="eventArgs">The event's arguments.</param>
 		/// <returns>A Task.</returns>
-		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+		private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventArgs)
 		{
 			// foreach request add
 			foreach (var req in this._requests)
 			{
-				if (req.Message.Id == eventargs.Message.Id)
+				if (req.Message.Id == eventArgs.Message.Id)
 				{
 					req.Collected.Clear();
 				}

--- a/DisCatSharp.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DisCatSharp.Interactivity/Extensions/ChannelExtensions.cs
@@ -81,7 +81,7 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// Sends a new paginated message.
 		/// </summary>
 		/// <param name="channel">Target channel.</param>
-		/// <param name="user">The user that'll be able to control the pages.</param>
+		/// <param name="user">The user that will be able to control the pages.</param>
 		/// <param name="pages">A collection of <see cref="Page"/> to display.</param>
 		/// <param name="emojis">Pagination emojis.</param>
 		/// <param name="behaviour">Pagination behaviour (when hitting max and min indices).</param>
@@ -95,7 +95,7 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// Sends a new paginated message with buttons.
 		/// </summary>
 		/// <param name="channel">Target channel.</param>
-		/// <param name="user">The user that'll be able to control the pages.</param>
+		/// <param name="user">The user that will be able to control the pages.</param>
 		/// <param name="pages">A collection of <see cref="Page"/> to display.</param>
 		/// <param name="buttons">Pagination buttons (leave null to default to ones on configuration).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
@@ -113,7 +113,7 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// Sends a new paginated message with buttons.
 		/// </summary>
 		/// <param name="channel">Target channel.</param>
-		/// <param name="user">The user that'll be able to control the pages.</param>
+		/// <param name="user">The user that will be able to control the pages.</param>
 		/// <param name="pages">A collection of <see cref="Page"/> to display.</param>
 		/// <param name="buttons">Pagination buttons (leave null to default to ones on configuration).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>

--- a/DisCatSharp.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DisCatSharp.Interactivity/Extensions/ChannelExtensions.cs
@@ -86,10 +86,10 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// <param name="emojis">Pagination emojis.</param>
 		/// <param name="behaviour">Pagination behaviour (when hitting max and min indices).</param>
 		/// <param name="deletion">Deletion behaviour.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
-			=> GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, emojis, behaviour, deletion, timeoutoverride);
+		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutOverride = null)
+			=> GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, emojis, behaviour, deletion, timeoutOverride);
 
 		/// <summary>
 		/// Sends a new paginated message with buttons.
@@ -117,11 +117,11 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// <param name="pages">A collection of <see cref="Page"/> to display.</param>
 		/// <param name="buttons">Pagination buttons (leave null to default to ones on configuration).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
-		/// <param name="deletion">Deletion behaviour</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="deletion">Deletion behaviour.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, TimeSpan? timeoutoverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
-			=> GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, buttons, timeoutoverride, behaviour, deletion);
+		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, TimeSpan? timeoutOverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
+			=> GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, buttons, timeoutOverride, behaviour, deletion);
 
 
 		/// <summary>
@@ -130,12 +130,12 @@ namespace DisCatSharp.Interactivity.Extensions
 		/// <param name="channel">The channel.</param>
 		/// <param name="user">The user.</param>
 		/// <param name="pages">The pages.</param>
-		/// <param name="timeoutoverride">The timeoutoverride.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		/// <param name="behaviour">The behaviour.</param>
 		/// <param name="deletion">The deletion.</param>
 		/// <returns>A Task.</returns>
-		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, TimeSpan? timeoutoverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
-			=> channel.SendPaginatedMessageAsync(user, pages, default, timeoutoverride, behaviour, deletion);
+		public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, TimeSpan? timeoutOverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
+			=> channel.SendPaginatedMessageAsync(user, pages, default, timeoutOverride, behaviour, deletion);
 
 		/// <summary>
 		/// Retrieves an interactivity instance from a channel instance.

--- a/DisCatSharp.Interactivity/InteractivityExtension.cs
+++ b/DisCatSharp.Interactivity/InteractivityExtension.cs
@@ -119,10 +119,10 @@ namespace DisCatSharp.Interactivity
 
 			var res = await this._poller.DoPollAsync(new PollRequest(m, timeout ?? this.Config.Timeout, emojis)).ConfigureAwait(false);
 
-			var pollbehaviour = behaviour ?? this.Config.PollBehaviour;
-			var thismember = await m.Channel.Guild.GetMemberAsync(this.Client.CurrentUser.Id).ConfigureAwait(false);
+			var pollBehaviour = behaviour ?? this.Config.PollBehaviour;
+			var thisMember = await m.Channel.Guild.GetMemberAsync(this.Client.CurrentUser.Id).ConfigureAwait(false);
 
-			if (pollbehaviour == PollBehaviour.DeleteEmojis && m.Channel.PermissionsFor(thismember).HasPermission(Permissions.ManageMessages))
+			if (pollBehaviour == PollBehaviour.DeleteEmojis && m.Channel.PermissionsFor(thisMember).HasPermission(Permissions.ManageMessages))
 				await m.DeleteAllReactionsAsync().ConfigureAwait(false);
 
 			return new ReadOnlyCollection<PollEmoji>(res.ToList());

--- a/DisCatSharp.Interactivity/InteractivityExtension.cs
+++ b/DisCatSharp.Interactivity/InteractivityExtension.cs
@@ -104,7 +104,7 @@ namespace DisCatSharp.Interactivity
 		/// <param name="m">Message to create poll on.</param>
 		/// <param name="emojis">Emojis to use for this poll.</param>
 		/// <param name="behaviour">What to do when the poll ends.</param>
-		/// <param name="timeout">override timeout period.</param>
+		/// <param name="timeout">Override timeout period.</param>
 		/// <returns></returns>
 		public async Task<ReadOnlyCollection<PollEmoji>> DoPollAsync(DiscordMessage m, IEnumerable<DiscordEmoji> emojis, PollBehaviour? behaviour = default, TimeSpan? timeout = null)
 		{
@@ -651,7 +651,7 @@ namespace DisCatSharp.Interactivity
 		/// <param name="pages">The pages.</param>
 		/// <param name="buttons">Pagination buttons (pass null to use buttons defined in <see cref="InteractivityConfiguration"/>).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
-		/// <param name="deletion">Deletion behaviour</param>
+		/// <param name="deletion">Deletion behaviour.</param>
 		/// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
 		public async Task SendPaginatedMessageAsync(
 			DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons,
@@ -688,8 +688,8 @@ namespace DisCatSharp.Interactivity
 		/// <param name="pages">The pages.</param>
 		/// <param name="buttons">Pagination buttons (pass null to use buttons defined in <see cref="InteractivityConfiguration"/>).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
-		/// <param name="deletion">Deletion behaviour</param>
 		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="deletion">Deletion behaviour.</param>
 		public Task SendPaginatedMessageAsync(
 			DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, TimeSpan? timeoutoverride,
 			PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
@@ -761,9 +761,9 @@ namespace DisCatSharp.Interactivity
 		/// <param name="ephemeral">Whether the response should be ephemeral.</param>
 		/// <param name="user">The user to listen for button presses from.</param>
 		/// <param name="pages">The pages to paginate.</param>
-		/// <param name="buttons">Optional: custom buttons</param>
+		/// <param name="buttons">Optional: custom buttons.</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
-		/// <param name="deletion">Deletion behaviour</param>
+		/// <param name="deletion">Deletion behaviour.</param>
 		/// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
 		public async Task SendPaginatedResponseAsync(DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
 		{

--- a/DisCatSharp.Interactivity/InteractivityExtension.cs
+++ b/DisCatSharp.Interactivity/InteractivityExtension.cs
@@ -478,14 +478,14 @@ namespace DisCatSharp.Interactivity
 		/// Waits for a specific message.
 		/// </summary>
 		/// <param name="predicate">Predicate to match.</param>
-		/// <param name="timeoutoverride">override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<DiscordMessage>> WaitForMessageAsync(Func<DiscordMessage, bool> predicate,
-			TimeSpan? timeoutoverride = null)
+			TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasMessageIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No message intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var returns = await this._messageCreatedWaiter.WaitForMatchAsync(new MatchRequest<MessageCreateEventArgs>(x => predicate(x.Message), timeout)).ConfigureAwait(false);
 
 			return new InteractivityResult<DiscordMessage>(returns == null, returns?.Message);
@@ -495,14 +495,14 @@ namespace DisCatSharp.Interactivity
 		/// Wait for a specific reaction.
 		/// </summary>
 		/// <param name="predicate">Predicate to match.</param>
-		/// <param name="timeoutoverride">override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(Func<MessageReactionAddEventArgs, bool> predicate,
-			TimeSpan? timeoutoverride = null)
+			TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasReactionIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No reaction intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var returns = await this._messageReactionAddWaiter.WaitForMatchAsync(new MatchRequest<MessageReactionAddEventArgs>(predicate, timeout)).ConfigureAwait(false);
 
 			return new InteractivityResult<MessageReactionAddEventArgs>(returns == null, returns);
@@ -514,10 +514,10 @@ namespace DisCatSharp.Interactivity
 		/// </summary>
 		/// <param name="message">Message reaction was added to.</param>
 		/// <param name="user">User that made the reaction.</param>
-		/// <param name="timeoutoverride">override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(DiscordMessage message, DiscordUser user,
-			TimeSpan? timeoutoverride = null)
-			=> await this.WaitForReactionAsync(x => x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride).ConfigureAwait(false);
+			TimeSpan? timeoutOverride = null)
+			=> await this.WaitForReactionAsync(x => x.User.Id == user.Id && x.Message.Id == message.Id, timeoutOverride).ConfigureAwait(false);
 
 		/// <summary>
 		/// Waits for a specific reaction.
@@ -526,10 +526,10 @@ namespace DisCatSharp.Interactivity
 		/// <param name="predicate">Predicate to match.</param>
 		/// <param name="message">Message reaction was added to.</param>
 		/// <param name="user">User that made the reaction.</param>
-		/// <param name="timeoutoverride">override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(Func<MessageReactionAddEventArgs, bool> predicate,
-			DiscordMessage message, DiscordUser user, TimeSpan? timeoutoverride = null)
-			=> await this.WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride).ConfigureAwait(false);
+			DiscordMessage message, DiscordUser user, TimeSpan? timeoutOverride = null)
+			=> await this.WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id && x.Message.Id == message.Id, timeoutOverride).ConfigureAwait(false);
 
 		/// <summary>
 		/// Waits for a specific reaction.
@@ -537,24 +537,24 @@ namespace DisCatSharp.Interactivity
 		/// </summary>
 		/// <param name="predicate">predicate to match.</param>
 		/// <param name="user">User that made the reaction.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(Func<MessageReactionAddEventArgs, bool> predicate,
-			DiscordUser user, TimeSpan? timeoutoverride = null)
-			=> await this.WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id, timeoutoverride).ConfigureAwait(false);
+			DiscordUser user, TimeSpan? timeoutOverride = null)
+			=> await this.WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id, timeoutOverride).ConfigureAwait(false);
 
 		/// <summary>
 		/// Waits for a user to start typing.
 		/// </summary>
 		/// <param name="user">User that starts typing.</param>
 		/// <param name="channel">Channel the user is typing in.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task<InteractivityResult<TypingStartEventArgs>> WaitForUserTypingAsync(DiscordUser user,
-			DiscordChannel channel, TimeSpan? timeoutoverride = null)
+			DiscordChannel channel, TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasTypingIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No typing intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var returns = await this._typingStartWaiter.WaitForMatchAsync(
 				new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id && x.Channel.Id == channel.Id, timeout))
 				.ConfigureAwait(false);
@@ -566,13 +566,13 @@ namespace DisCatSharp.Interactivity
 		/// Waits for a user to start typing.
 		/// </summary>
 		/// <param name="user">User that starts typing.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
-		public async Task<InteractivityResult<TypingStartEventArgs>> WaitForUserTypingAsync(DiscordUser user, TimeSpan? timeoutoverride = null)
+		/// <param name="timeoutOverride">Override timeout period.</param>
+		public async Task<InteractivityResult<TypingStartEventArgs>> WaitForUserTypingAsync(DiscordUser user, TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasTypingIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No typing intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var returns = await this._typingStartWaiter.WaitForMatchAsync(
 				new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id, timeout))
 				.ConfigureAwait(false);
@@ -584,13 +584,13 @@ namespace DisCatSharp.Interactivity
 		/// Waits for any user to start typing.
 		/// </summary>
 		/// <param name="channel">Channel to type in.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
-		public async Task<InteractivityResult<TypingStartEventArgs>> WaitForTypingAsync(DiscordChannel channel, TimeSpan? timeoutoverride = null)
+		/// <param name="timeoutOverride">Override timeout period.</param>
+		public async Task<InteractivityResult<TypingStartEventArgs>> WaitForTypingAsync(DiscordChannel channel, TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasTypingIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No typing intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var returns = await this._typingStartWaiter.WaitForMatchAsync(
 				new MatchRequest<TypingStartEventArgs>(x => x.Channel.Id == channel.Id, timeout))
 				.ConfigureAwait(false);
@@ -602,13 +602,13 @@ namespace DisCatSharp.Interactivity
 		/// Collects reactions on a specific message.
 		/// </summary>
 		/// <param name="m">Message to collect reactions on.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
-		public async Task<ReadOnlyCollection<Reaction>> CollectReactionsAsync(DiscordMessage m, TimeSpan? timeoutoverride = null)
+		/// <param name="timeoutOverride">Override timeout period.</param>
+		public async Task<ReadOnlyCollection<Reaction>> CollectReactionsAsync(DiscordMessage m, TimeSpan? timeoutOverride = null)
 		{
 			if (!Utilities.HasReactionIntents(this.Client.Configuration.Intents))
 				throw new InvalidOperationException("No reaction intents are enabled.");
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 			var collection = await this._reactionCollector.CollectAsync(new ReactionCollectRequest(m, timeout)).ConfigureAwait(false);
 
 			return collection;
@@ -619,10 +619,10 @@ namespace DisCatSharp.Interactivity
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="predicate">The predicate.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
-		public async Task<InteractivityResult<T>> WaitForEventArgsAsync<T>(Func<T, bool> predicate, TimeSpan? timeoutoverride = null) where T : AsyncEventArgs
+		/// <param name="timeoutOverride">Override timeout period.</param>
+		public async Task<InteractivityResult<T>> WaitForEventArgsAsync<T>(Func<T, bool> predicate, TimeSpan? timeoutOverride = null) where T : AsyncEventArgs
 		{
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 
 			using var waiter = new EventWaiter<T>(this.Client);
 			var res = await waiter.WaitForMatchAsync(new MatchRequest<T>(predicate, timeout)).ConfigureAwait(false);
@@ -633,10 +633,10 @@ namespace DisCatSharp.Interactivity
 		/// Collects the event arguments.
 		/// </summary>
 		/// <param name="predicate">The predicate.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
-		public async Task<ReadOnlyCollection<T>> CollectEventArgsAsync<T>(Func<T, bool> predicate, TimeSpan? timeoutoverride = null) where T : AsyncEventArgs
+		/// <param name="timeoutOverride">Override timeout period.</param>
+		public async Task<ReadOnlyCollection<T>> CollectEventArgsAsync<T>(Func<T, bool> predicate, TimeSpan? timeoutOverride = null) where T : AsyncEventArgs
 		{
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 
 			using var waiter = new EventWaiter<T>(this.Client);
 			var res = await waiter.CollectMatchesAsync(new CollectRequest<T>(predicate, timeout)).ConfigureAwait(false);
@@ -688,12 +688,12 @@ namespace DisCatSharp.Interactivity
 		/// <param name="pages">The pages.</param>
 		/// <param name="buttons">Pagination buttons (pass null to use buttons defined in <see cref="InteractivityConfiguration"/>).</param>
 		/// <param name="behaviour">Pagination behaviour.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
 		/// <param name="deletion">Deletion behaviour.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public Task SendPaginatedMessageAsync(
-			DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, TimeSpan? timeoutoverride,
+			DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, TimeSpan? timeoutOverride,
 			PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
-			=> this.SendPaginatedMessageAsync(channel, user, pages, buttons, behaviour, deletion, this.GetCancellationToken(timeoutoverride));
+			=> this.SendPaginatedMessageAsync(channel, user, pages, buttons, behaviour, deletion, this.GetCancellationToken(timeoutOverride));
 
 		/// <summary>
 		/// Sends the paginated message.
@@ -714,12 +714,12 @@ namespace DisCatSharp.Interactivity
 		/// <param name="channel">The channel.</param>
 		/// <param name="user">The user.</param>
 		/// <param name="pages">The pages.</param>
-		/// <param name="timeoutoverride">The timeoutoverride.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		/// <param name="behaviour">The behaviour.</param>
 		/// <param name="deletion">The deletion.</param>
 		/// <returns>A Task.</returns>
-		public Task SendPaginatedMessageAsync(DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, TimeSpan? timeoutoverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
-			=> this.SendPaginatedMessageAsync(channel, user, pages, timeoutoverride, behaviour, deletion);
+		public Task SendPaginatedMessageAsync(DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, TimeSpan? timeoutOverride, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
+			=> this.SendPaginatedMessageAsync(channel, user, pages, timeoutOverride, behaviour, deletion);
 
 		/// <summary>
 		/// Sends a paginated message.
@@ -731,24 +731,24 @@ namespace DisCatSharp.Interactivity
 		/// <param name="emojis">Pagination emojis.</param>
 		/// <param name="behaviour">Pagination behaviour (when hitting max and min indices).</param>
 		/// <param name="deletion">Deletion behaviour.</param>
-		/// <param name="timeoutoverride">Override timeout period.</param>
+		/// <param name="timeoutOverride">Override timeout period.</param>
 		public async Task SendPaginatedMessageAsync(DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis,
-			PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
+			PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutOverride = null)
 		{
 			var builder = new DiscordMessageBuilder()
 				.WithContent(pages.First().Content)
 				.WithEmbed(pages.First().Embed);
 			var m = await builder.SendAsync(channel).ConfigureAwait(false);
 
-			var timeout = timeoutoverride ?? this.Config.Timeout;
+			var timeout = timeoutOverride ?? this.Config.Timeout;
 
 			var bhv = behaviour ?? this.Config.PaginationBehaviour;
 			var del = deletion ?? this.Config.PaginationDeletion;
 			var ems = emojis ?? this.Config.PaginationEmojis;
 
-			var prequest = new PaginationRequest(m, user, bhv, del, ems, timeout, pages.ToArray());
+			var pRequest = new PaginationRequest(m, user, bhv, del, ems, timeout, pages.ToArray());
 
-			await this._paginator.DoPaginationAsync(prequest).ConfigureAwait(false);
+			await this._paginator.DoPaginationAsync(pRequest).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -813,9 +813,9 @@ namespace DisCatSharp.Interactivity
 		/// Generates pages from a string, and puts them in message content.
 		/// </summary>
 		/// <param name="input">Input string.</param>
-		/// <param name="splittype">How to split input string.</param>
+		/// <param name="splitType">How to split input string.</param>
 		/// <returns></returns>
-		public IEnumerable<Page> GeneratePagesInContent(string input, SplitType splittype = SplitType.Character)
+		public IEnumerable<Page> GeneratePagesInContent(string input, SplitType splitType = SplitType.Character)
 		{
 			if (string.IsNullOrEmpty(input))
 				throw new ArgumentException("You must provide a string that is not null or empty!");
@@ -823,7 +823,7 @@ namespace DisCatSharp.Interactivity
 			var result = new List<Page>();
 			List<string> split;
 
-			switch (splittype)
+			switch (splitType)
 			{
 				default:
 				case SplitType.Character:
@@ -863,20 +863,20 @@ namespace DisCatSharp.Interactivity
 		/// Generates pages from a string, and puts them in message embeds.
 		/// </summary>
 		/// <param name="input">Input string.</param>
-		/// <param name="splittype">How to split input string.</param>
-		/// <param name="embedbase">Base embed for output embeds.</param>
+		/// <param name="splitType">How to split input string.</param>
+		/// <param name="embedBase">Base embed for output embeds.</param>
 		/// <returns></returns>
-		public IEnumerable<Page> GeneratePagesInEmbed(string input, SplitType splittype = SplitType.Character, DiscordEmbedBuilder embedbase = null)
+		public IEnumerable<Page> GeneratePagesInEmbed(string input, SplitType splitType = SplitType.Character, DiscordEmbedBuilder embedBase = null)
 		{
 			if (string.IsNullOrEmpty(input))
 				throw new ArgumentException("You must provide a string that is not null or empty!");
 
-			var embed = embedbase ?? new DiscordEmbedBuilder();
+			var embed = embedBase ?? new DiscordEmbedBuilder();
 
 			var result = new List<Page>();
 			List<string> split;
 
-			switch (splittype)
+			switch (splitType)
 			{
 				default:
 				case SplitType.Character:

--- a/DisCatSharp.Interactivity/InteractivityResult.cs
+++ b/DisCatSharp.Interactivity/InteractivityResult.cs
@@ -40,11 +40,11 @@ namespace DisCatSharp.Interactivity
 		/// <summary>
 		/// Initializes a new instance of the <see cref="InteractivityResult{T}"/> class.
 		/// </summary>
-		/// <param name="timedout">If true, timedout.</param>
+		/// <param name="timedOut">If true, timed out.</param>
 		/// <param name="result">The result.</param>
-		internal InteractivityResult(bool timedout, T result)
+		internal InteractivityResult(bool timedOut, T result)
 		{
-			this.TimedOut = timedout;
+			this.TimedOut = timedOut;
 			this.Result = result;
 		}
 	}

--- a/DisCatSharp.Lavalink/Entities/LavalinkEqualizerTypes.cs
+++ b/DisCatSharp.Lavalink/Entities/LavalinkEqualizerTypes.cs
@@ -71,7 +71,7 @@ namespace DisCatSharp.Lavalink
 		/// Whether two band adjustments are equal.
 		/// </summary>
 		/// <param name="x">The first band adjustments.</param>
-		/// <param name="y">The seconed band adjustments.</param>
+		/// <param name="y">The second band adjustments.</param>
 		public bool Equals(LavalinkBandAdjustment x, LavalinkBandAdjustment y)
 			=> x.BandId == y.BandId;
 

--- a/DisCatSharp.Lavalink/Entities/LavalinkRouteStatus.cs
+++ b/DisCatSharp.Lavalink/Entities/LavalinkRouteStatus.cs
@@ -142,7 +142,7 @@ namespace DisCatSharp.Lavalink.Entities
 		public string Address { get; internal set; }
 
 		/// <summary>
-		/// Gets the failing timestamp in miliseconds.
+		/// Gets the failing timestamp in milliseconds.
 		/// </summary>
 		[JsonProperty("failingTimestamp", NullValueHandling = NullValueHandling.Ignore)]
 		public ulong FailingTimestamp { get; internal set; }

--- a/DisCatSharp.Lavalink/LavalinkConfiguration.cs
+++ b/DisCatSharp.Lavalink/LavalinkConfiguration.cs
@@ -69,9 +69,9 @@ namespace DisCatSharp.Lavalink
 		public int ResumeTimeout { internal get; set; } = 60;
 
 		/// <summary>
-		/// Sets the time in miliseconds to wait for Lavalink's voice WebSocket to close after leaving a voice channel.
+		/// Sets the time in milliseconds to wait for Lavalink's voice WebSocket to close after leaving a voice channel.
 		/// <para>This will be the delay before the guild connection is removed.</para>
-		/// <para>Defaults to 3000 miliseconds.</para>
+		/// <para>Defaults to 3000 milliseconds.</para>
 		/// </summary>
 		public int WebSocketCloseTimeout { internal get; set; } = 3000;
 

--- a/DisCatSharp.Lavalink/LavalinkRestEndpoints.cs
+++ b/DisCatSharp.Lavalink/LavalinkRestEndpoints.cs
@@ -48,7 +48,7 @@ namespace DisCatSharp.Lavalink
 
 		//Route Planner
 		/// <summary>
-		/// The reoute planner endpoint.
+		/// The route planner endpoint.
 		/// </summary>
 		internal const string ROUTE_PLANNER = "/routeplanner";
 		/// <summary>

--- a/DisCatSharp.Lavalink/LavalinkUtil.cs
+++ b/DisCatSharp.Lavalink/LavalinkUtil.cs
@@ -34,7 +34,7 @@ namespace DisCatSharp.Lavalink
 	public static class LavalinkUtilities
 	{
 		/// <summary>
-		/// Indicates whether a new track should be started after reciving this TrackEndReason. If this is false, either this event is
+		/// Indicates whether a new track should be started after receiving this TrackEndReason. If this is false, either this event is
 		/// already triggered because another track started (REPLACED) or because the player is stopped (STOPPED, CLEANUP).
 		/// </summary>
 		public static bool MayStartNext(this TrackEndReason reason)

--- a/DisCatSharp.VoiceNext/AudioFormat.cs
+++ b/DisCatSharp.VoiceNext/AudioFormat.cs
@@ -49,7 +49,7 @@ namespace DisCatSharp.VoiceNext
 		public static IReadOnlyCollection<int> AllowedSampleDurations { get; } = new ReadOnlyCollection<int>(new[] { 5, 10, 20, 40, 60 });
 
 		/// <summary>
-		/// Gets the default audio format. This is a formt configured for 48kHz sampling rate, 2 channels, with music quality preset.
+		/// Gets the default audio format. This is a format configured for 48kHz sampling rate, 2 channels, with music quality preset.
 		/// </summary>
 		public static AudioFormat Default { get; } = new(48000, 2, VoiceApplication.Music);
 
@@ -93,7 +93,7 @@ namespace DisCatSharp.VoiceNext
 		/// <summary>
 		/// Calculates a sample size in bytes.
 		/// </summary>
-		/// <param name="sampleDuration">Millsecond duration of a sample.</param>
+		/// <param name="sampleDuration">Millisecond duration of a sample.</param>
 		/// <returns>Calculated sample size in bytes.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public int CalculateSampleSize(int sampleDuration)

--- a/DisCatSharp.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
+++ b/DisCatSharp.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
@@ -59,7 +59,7 @@ namespace DisCatSharp.VoiceNext.EventArgs
 		/// <summary>
 		/// Gets the format of the received PCM data.
 		/// <para>
-		/// Important: This isn't always the format set in <see cref="VoiceNextConfiguration.AudioFormat"/>, and depends on the audio data recieved.
+		/// Important: This isn't always the format set in <see cref="VoiceNextConfiguration.AudioFormat"/>, and depends on the audio data received.
 		/// </para>
 		/// </summary>
 		public AudioFormat AudioFormat { get; internal set; }

--- a/DisCatSharp.VoiceNext/VoiceNextConnection.cs
+++ b/DisCatSharp.VoiceNext/VoiceNextConnection.cs
@@ -897,7 +897,7 @@ namespace DisCatSharp.VoiceNext
 		}
 
 		/// <summary>
-		/// Asynchronously waits for playback to be finished. Playback is finished when speaking = false is signalled.
+		/// Asynchronously waits for playback to be finished. Playback is finished when speaking = false is signaled.
 		/// </summary>
 		/// <returns>A task representing the waiting operation.</returns>
 		public async Task WaitForPlaybackFinishAsync()
@@ -1059,7 +1059,7 @@ namespace DisCatSharp.VoiceNext
 				Address = ip,
 				Port = port
 			};
-			this._discord.Logger.LogTrace(VoiceNextEvents.VoiceHandshake, "Endpoint dicovery finished - discovered endpoint is {0}:{1}", ip, port);
+			this._discord.Logger.LogTrace(VoiceNextEvents.VoiceHandshake, "Endpoint discovery finished - discovered endpoint is {0}:{1}", ip, port);
 
 			void PreparePacket(byte[] packet)
 			{
@@ -1343,7 +1343,7 @@ namespace DisCatSharp.VoiceNext
 		/// <summary>
 		/// Gets the unix timestamp.
 		/// </summary>
-		/// <param name="dt">The datetine.</param>
+		/// <param name="dt">The datetime.</param>
 		private static uint UnixTimestamp(DateTime dt)
 		{
 			var ts = dt - s_unixEpoch;

--- a/DisCatSharp/Clients/DiscordClient.cs
+++ b/DisCatSharp/Clients/DiscordClient.cs
@@ -923,7 +923,7 @@ namespace DisCatSharp
 
 
 		/// <summary>
-		/// Gets the internal chached scheduled event.
+		/// Gets the internal cached scheduled event.
 		/// </summary>
 		/// <param name="scheduledEventId">The target scheduled event id.</param>
 		/// <returns>The requested scheduled event.</returns>
@@ -937,7 +937,7 @@ namespace DisCatSharp
 		}
 
 		/// <summary>
-		/// Gets the internal chached channel.
+		/// Gets the internal cached channel.
 		/// </summary>
 		/// <param name="channelId">The target channel id.</param>
 		/// <returns>The requested channel.</returns>

--- a/DisCatSharp/Clients/DiscordShardedClient.Events.cs
+++ b/DisCatSharp/Clients/DiscordShardedClient.Events.cs
@@ -1283,7 +1283,7 @@ namespace DisCatSharp
 			=> this._guildMemberUpdated.InvokeAsync(client, e);
 
 		/// <summary>
-		/// Handles the guild role creat evente.
+		/// Handles the guild role create event.
 		/// </summary>
 		/// <param name="client">The client.</param>
 		/// <param name="e">The event args.</param>
@@ -1451,7 +1451,7 @@ namespace DisCatSharp
 			=> this._webhooksUpdated.InvokeAsync(client, e);
 
 		/// <summary>
-		/// Handles the heart beated event.
+		/// Handles the heartbeated event.
 		/// </summary>
 		/// <param name="client">The client.</param>
 		/// <param name="e">The event args.</param>

--- a/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
+++ b/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
@@ -136,28 +136,24 @@ namespace DisCatSharp.Entities
 		/// <param name="maximumValue">The maximum value for this parameter. Only valid for types <see cref="ApplicationCommandOptionType.Integer"/> or <see cref="ApplicationCommandOptionType.Number"/>.</param>
 		/// <param name="nameLocalizations">The localizations of the parameter name.</param>
 		/// <param name="descriptionLocalizations">The localizations of the parameter description.</param>
-		public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channeltypes = null, bool? autocomplete = null, object minimumValue = null, object maximumValue = null, DiscordApplicationCommandLocalization nameLocalizations = null, DiscordApplicationCommandLocalization descriptionLocalizations = null)
+		public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null, bool? autocomplete = null, object minimumValue = null, object maximumValue = null, DiscordApplicationCommandLocalization nameLocalizations = null, DiscordApplicationCommandLocalization descriptionLocalizations = null)
 		{
 			if (!Utilities.IsValidSlashCommandName(name))
 				throw new ArgumentException("Invalid application command option name specified. It must be below 32 characters and not contain any whitespace.", nameof(name));
-			if (name.Any(ch => char.IsUpper(ch)))
+			if (name.Any(char.IsUpper))
 				throw new ArgumentException("Application command option name cannot have any upper case characters.", nameof(name));
 			if (description.Length > 100)
 				throw new ArgumentException("Application command option description cannot exceed 100 characters.", nameof(description));
 			if ((autocomplete ?? false) && (choices?.Any() ?? false))
 				throw new InvalidOperationException("Auto-complete slash command options cannot provide choices.");
 
-			var choiceList = choices != null ? new ReadOnlyCollection<DiscordApplicationCommandOptionChoice>(choices.ToList()) : null;
-			var optionList = options != null ? new ReadOnlyCollection<DiscordApplicationCommandOption>(options.ToList()) : null;
-			var channelTypes = channeltypes!= null ? new ReadOnlyCollection<ChannelType>(channeltypes.ToList()) : null;
-
 			this.Name = name;
 			this.Description = description;
 			this.Type = type;
 			this.Required = required;
-			this.Choices = choiceList;
-			this.Options = optionList;
-			this.ChannelTypes = channelTypes;
+			this.Choices = choices != null ? new ReadOnlyCollection<DiscordApplicationCommandOptionChoice>(choices.ToList()) : null;
+			this.Options = options != null ? new ReadOnlyCollection<DiscordApplicationCommandOption>(options.ToList()) : null;
+			this.ChannelTypes = channelTypes != null ? new ReadOnlyCollection<ChannelType>(channelTypes.ToList()) : null;
 			this.AutoComplete = autocomplete;
 			this.MinimumValue = minimumValue;
 			this.MaximumValue = maximumValue;

--- a/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
+++ b/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
@@ -130,7 +130,7 @@ namespace DisCatSharp.Entities
 		/// <param name="required">Whether the parameter is required.</param>
 		/// <param name="choices">The optional choice selection for this parameter.</param>
 		/// <param name="options">The optional subcommands for this parameter.</param>
-		/// <param name="channeltypes">If the option is a channel type, the channels shown will be restricted to these types</param>
+		/// <param name="channelTypes">If the option is a channel type, the channels shown will be restricted to these types.</param>
 		/// <param name="autocomplete">Whether this option provides autocompletion.</param>
 		/// <param name="minimumValue">The minimum value for this parameter. Only valid for types <see cref="ApplicationCommandOptionType.Integer"/> or <see cref="ApplicationCommandOptionType.Number"/>.</param>
 		/// <param name="maximumValue">The maximum value for this parameter. Only valid for types <see cref="ApplicationCommandOptionType.Integer"/> or <see cref="ApplicationCommandOptionType.Number"/>.</param>

--- a/DisCatSharp/Entities/Channel/DiscordChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordChannel.cs
@@ -74,13 +74,13 @@ namespace DisCatSharp.Entities
 		public ChannelType Type { get; internal set; }
 
 		/// <summary>
-		/// Gets this channels's banner hash, when applicable.
+		/// Gets this channel's banner hash, when applicable.
 		/// </summary>
 		[JsonProperty("banner")]
 		public string BannerHash { get; internal set; }
 
 		/// <summary>
-		/// Gets this channels's banner in url form.
+		/// Gets this channel's banner in url form.
 		/// </summary>
 		[JsonIgnore]
 		public string BannerUrl
@@ -94,7 +94,7 @@ namespace DisCatSharp.Entities
 
 		/// <summary>
 		/// Gets the maximum available position to move the channel to.
-		/// This can contain outdated informations.
+		/// This can contain outdated information.
 		/// </summary>
 		public int GetMaxPosition()
 		{
@@ -586,7 +586,7 @@ namespace DisCatSharp.Entities
 		}
 
 		/// <summary>
-		/// Internaly refreshes the channel list.
+		/// Internally refreshes the channel list.
 		/// </summary>
 		private async Task<IReadOnlyList<DiscordChannel>> InternalRefreshChannelsAsync()
 		{
@@ -972,7 +972,7 @@ namespace DisCatSharp.Entities
 		/// <param name="coverImage">The cover image.</param>
 		/// <param name="reason">The reason.</param>
 		/// <returns>A scheduled event.</returns>
-		/// <exception cref="DisCatSharp.Exceptions.NotFoundException">Thrown when the ressource does not exist.</exception>
+		/// <exception cref="DisCatSharp.Exceptions.NotFoundException">Thrown when the resource does not exist.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public async Task<DiscordScheduledEvent> CreateScheduledEventAsync(string name, DateTimeOffset scheduledStartTime, string description = null, Optional<Stream> coverImage = default, string reason = null)
@@ -1122,7 +1122,7 @@ namespace DisCatSharp.Entities
 			=> this.Discord.ApiClient.DeleteChannelPermissionAsync(this.Id, role.Id, reason);
 
 		/// <summary>
-		/// Post a typing indicator
+		/// Post a typing indicator.
 		/// </summary>
 		/// <exception cref="DisCatSharp.Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
@@ -1133,7 +1133,7 @@ namespace DisCatSharp.Entities
 				: this.Discord.ApiClient.TriggerTypingAsync(this.Id);
 
 		/// <summary>
-		/// Returns all pinned messages
+		/// Returns all pinned messages.
 		/// </summary>
 		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.AccessChannels"/> permission.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
@@ -1145,7 +1145,7 @@ namespace DisCatSharp.Entities
 				: this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
 
 		/// <summary>
-		/// Create a new webhook
+		/// Create a new webhook.
 		/// </summary>
 		/// <param name="name">The name of the webhook.</param>
 		/// <param name="avatar">The image for the default webhook avatar.</param>
@@ -1167,7 +1167,7 @@ namespace DisCatSharp.Entities
 		}
 
 		/// <summary>
-		/// Returns a list of webhooks
+		/// Returns a list of webhooks.
 		/// </summary>
 		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.ManageWebhooks"/> permission.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
@@ -1176,7 +1176,7 @@ namespace DisCatSharp.Entities
 			=> this.Discord.ApiClient.GetChannelWebhooksAsync(this.Id);
 
 		/// <summary>
-		/// Moves a member to this voice channel
+		/// Moves a member to this voice channel.
 		/// </summary>
 		/// <param name="member">The member to be moved.</param>
 		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.MoveMembers"/> permission.</exception>
@@ -1193,21 +1193,21 @@ namespace DisCatSharp.Entities
 		}
 
 		/// <summary>
-		/// Follows a news channel
+		/// Follows a news channel.
 		/// </summary>
-		/// <param name="targetChannel">Channel to crosspost messages to</param>
-		/// <exception cref="System.ArgumentException">Thrown when trying to follow a non-news channel</exception>
-		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">Thrown when the current user doesn't have <see cref="Permissions.ManageWebhooks"/> on the target channel</exception>
+		/// <param name="targetChannel">Channel to crosspost messages to.</param>
+		/// <exception cref="System.ArgumentException">Thrown when trying to follow a non-news channel.</exception>
+		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">Thrown when the current user doesn't have <see cref="Permissions.ManageWebhooks"/> on the target channel.</exception>
 		public Task<DiscordFollowedChannel> FollowAsync(DiscordChannel targetChannel) =>
 			this.Type != ChannelType.News
 				? throw new ArgumentException("Cannot follow a non-news channel.")
 				: this.Discord.ApiClient.FollowChannelAsync(this.Id, targetChannel.Id);
 
 		/// <summary>
-		/// Publishes a message in a news channel to following channels
+		/// Publishes a message in a news channel to following channels.
 		/// </summary>
-		/// <param name="message">Message to publish</param>
-		/// <exception cref="System.ArgumentException">Thrown when the message has already been crossposted</exception>
+		/// <param name="message">Message to publish.</param>
+		/// <exception cref="System.ArgumentException">Thrown when the message has already been crossposted.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.UnauthorizedException">
 		///     Thrown when the current user doesn't have <see cref="Permissions.ManageWebhooks"/> and/or <see cref="Permissions.SendMessages"/>
 		/// </exception>
@@ -1260,7 +1260,7 @@ namespace DisCatSharp.Entities
 			// assign permissions from member's roles (in order)
 			perms |= mbRoles.Aggregate(Permissions.None, (c, role) => c | role.Permissions);
 
-			// Adminstrator grants all permissions and cannot be overridden
+			// Administrator grants all permissions and cannot be overridden
 			if ((perms & Permissions.Administrator) == Permissions.Administrator)
 				return PermissionMethods.FullPerms;
 

--- a/DisCatSharp/Entities/Channel/DiscordChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordChannel.cs
@@ -294,7 +294,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public Task<DiscordMessage> SendMessageAsync(string content) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-text channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -308,7 +308,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-text channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed != null ? new[] { embed } : null, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -323,7 +323,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-text channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed != null ? new[] { embed } : null, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -354,7 +354,7 @@ namespace DisCatSharp.Entities
 			action(builder);
 
 
-			return !this.IsWriteable()
+			return !this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-text channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, builder);
 		}
@@ -402,7 +402,7 @@ namespace DisCatSharp.Entities
 			{
 				userLimit = null;
 			}
-			if (!this.IsWriteable())
+			if (!this.IsWritable())
 			{
 				perUserRateLimit = Optional.FromNoValue<int?>();
 			}
@@ -459,7 +459,7 @@ namespace DisCatSharp.Entities
 				bannerb64 = null;
 
 			return this.Discord.ApiClient.ModifyChannelAsync(this.Id, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
-				mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(r => r?.Id),
+				mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.UserLimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(r => r?.Id),
 				mdl.QualityMode, mdl.DefaultAutoArchiveDuration, mdl.Type, mdl.PermissionOverwrites, bannerb64, mdl.AuditLogReason);
 		}
 
@@ -796,7 +796,7 @@ namespace DisCatSharp.Entities
 		/// <param name="around">Get messages around snowflake.</param>
 		private async Task<IReadOnlyList<DiscordMessage>> GetMessagesInternalAsync(int limit = 100, ulong? before = null, ulong? after = null, ulong? around = null)
 		{
-			if (!this.IsWriteable())
+			if (!this.IsWritable())
 				throw new ArgumentException("Cannot get the messages of a non-text channel.");
 
 			if (limit < 0)
@@ -1128,7 +1128,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public Task TriggerTypingAsync() =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot start typing in a non-text channel.")
 				: this.Discord.ApiClient.TriggerTypingAsync(this.Id);
 
@@ -1140,7 +1140,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync() =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("A non-text channel does not have pinned messages.")
 				: this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
 

--- a/DisCatSharp/Entities/Channel/DiscordDmChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordDmChannel.cs
@@ -68,7 +68,7 @@ namespace DisCatSharp.Entities
 			=> !string.IsNullOrWhiteSpace(this.IconHash) ? $"{DiscordDomain.GetDomain(CoreDomain.DiscordCdn).Url}{Endpoints.CHANNEL_ICONS}/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.IconHash}.png" : null;
 
 		/// <summary>
-		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token
+		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token.
 		/// </summary>
 		/// <param name="userId">The id of the user to add.</param>
 		/// <param name="accesstoken">The OAuth2 access token.</param>
@@ -80,7 +80,7 @@ namespace DisCatSharp.Entities
 			=> this.Discord.ApiClient.AddGroupDmRecipientAsync(this.Id, userId, accesstoken, nickname);
 
 		/// <summary>
-		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token
+		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token.
 		/// </summary>
 		/// <param name="userId">The id of the User to remove.</param>
 		/// <param name="accesstoken">The OAuth2 access token.</param>

--- a/DisCatSharp/Entities/Channel/DiscordDmChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordDmChannel.cs
@@ -71,23 +71,23 @@ namespace DisCatSharp.Entities
 		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token.
 		/// </summary>
 		/// <param name="userId">The id of the user to add.</param>
-		/// <param name="accesstoken">The OAuth2 access token.</param>
+		/// <param name="accessToken">The OAuth2 access token.</param>
 		/// <param name="nickname">The nickname to give to the user.</param>
 		/// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
 		/// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-		public Task AddDmRecipientAsync(ulong userId, string accesstoken, string nickname)
-			=> this.Discord.ApiClient.AddGroupDmRecipientAsync(this.Id, userId, accesstoken, nickname);
+		public Task AddDmRecipientAsync(ulong userId, string accessToken, string nickname)
+			=> this.Discord.ApiClient.AddGroupDmRecipientAsync(this.Id, userId, accessToken, nickname);
 
 		/// <summary>
 		/// Only use for Group DMs! Whitelisted bots only. Requires user's oauth2 access token.
 		/// </summary>
 		/// <param name="userId">The id of the User to remove.</param>
-		/// <param name="accesstoken">The OAuth2 access token.</param>
+		/// <param name="accessToken">The OAuth2 access token.</param>
 		/// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
 		/// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-		public Task RemoveDmRecipientAsync(ulong userId, string accesstoken)
+		public Task RemoveDmRecipientAsync(ulong userId, string accessToken)
 			=> this.Discord.ApiClient.RemoveGroupDmRecipientAsync(this.Id, userId);
 	}
 }

--- a/DisCatSharp/Entities/DCS/DisCatSharpTeam.cs
+++ b/DisCatSharp/Entities/DCS/DisCatSharpTeam.cs
@@ -34,40 +34,40 @@ namespace DisCatSharp.Entities
 	public sealed class DisCatSharpTeam : SnowflakeObject
 	{
 		/// <summary>
-		/// Gets the team name.
+		/// Gets the team's name.
 		/// </summary>
 		public string TeamName { get; internal set; }
 
 		/// <summary>
-		/// Gets the teams's icon.
+		/// Gets the team's icon.
 		/// </summary>
 		public string Icon
 			=> !string.IsNullOrWhiteSpace(this.IconHash) ? $"{DiscordDomain.GetDomain(CoreDomain.DiscordCdn).Url}{Endpoints.TEAM_ICONS}/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.IconHash}.png?size=1024" : null;
 
 		/// <summary>
-		/// Gets the team's icon hash.
+		/// Gets the team's icon's hash.
 		/// </summary>
 		public string IconHash { get; internal set; }
 
 		/// <summary>
-		/// Gets the teams's logo.
+		/// Gets the team's logo.
 		/// </summary>
 		public string Logo
 			=> !string.IsNullOrWhiteSpace(this.LogoHash) ? $"{DiscordDomain.GetDomain(CoreDomain.DiscordCdn).Url}{Endpoints.ICONS}/{this.GuildId.ToString(CultureInfo.InvariantCulture)}/{this.LogoHash}.png?size=1024" : null;
 
 		/// <summary>
-		/// Gets the team's logo hash.
+		/// Gets the team's logo's hash.
 		/// </summary>
 		public string LogoHash { get; internal set; }
 
 		/// <summary>
-		/// Gets the teams's banner.
+		/// Gets the team's banner.
 		/// </summary>
 		public string Banner
 			=> !string.IsNullOrWhiteSpace(this.BannerHash) ? $"{DiscordDomain.GetDomain(CoreDomain.DiscordCdn).Url}{Endpoints.BANNERS}/{this.GuildId.ToString(CultureInfo.InvariantCulture)}/{this.BannerHash}.png?size=1024" : null;
 
 		/// <summary>
-		/// Gets the team's banner hash.
+		/// Gets the team's banner's hash.
 		/// </summary>
 		public string BannerHash { get; internal set; }
 

--- a/DisCatSharp/Entities/Guild/DiscordAuditLogObjects.cs
+++ b/DisCatSharp/Entities/Guild/DiscordAuditLogObjects.cs
@@ -821,7 +821,7 @@ namespace DisCatSharp.Entities
 		Delete,
 
 		/// <summary>
-		/// Indicates that this action resulted in something else than creation, addition, update, deleteion, or removal of an object.
+		/// Indicates that this action resulted in something else than creation, addition, update, deletion, or removal of an object.
 		/// </summary>
 		Other
 	}

--- a/DisCatSharp/Entities/Guild/DiscordMember.cs
+++ b/DisCatSharp/Entities/Guild/DiscordMember.cs
@@ -702,7 +702,7 @@ namespace DisCatSharp.Entities
 			// assign permissions from member's roles (in order)
 			perms |= this.Roles.Aggregate(Permissions.None, (c, role) => c | role.Permissions);
 
-			// Adminstrator grants all permissions and cannot be overridden
+			// Administrator grants all permissions and cannot be overridden
 			return (perms & Permissions.Administrator) == Permissions.Administrator ? PermissionMethods.FullPerms : perms;
 		}
 

--- a/DisCatSharp/Entities/Guild/ScheduledEvent/DiscordScheduledEvent.cs
+++ b/DisCatSharp/Entities/Guild/ScheduledEvent/DiscordScheduledEvent.cs
@@ -273,7 +273,7 @@ namespace DisCatSharp.Entities
 		/// <param name="limit">The limit how many users to receive from the event. Defaults to 100. Max 100.</param>
 		/// <param name="before">Get results of <see cref="DiscordScheduledEventUser"/> before the given snowflake.</param>
 		/// <param name="after">Get results of <see cref="DiscordScheduledEventUser"/> after the given snowflake.</param>
-		/// <param name="withMember">Wether to include guild member data.</param>
+		/// <param name="withMember">Whether to include guild member data.</param>
 		/// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the correct permissions.</exception>
 		/// <exception cref="Exceptions.NotFoundException">Thrown when the event does not exist.</exception>
 		/// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
@@ -321,7 +321,7 @@ namespace DisCatSharp.Entities
 		/// Gets whether the two <see cref="DiscordScheduledEvent"/> objects are equal.
 		/// </summary>
 		/// <param name="e1">First event to compare.</param>
-		/// <param name="e2">Second ecent to compare.</param>
+		/// <param name="e2">Second event to compare.</param>
 		/// <returns>Whether the two events are equal.</returns>
 		public static bool operator ==(DiscordScheduledEvent e1, DiscordScheduledEvent e2)
 		{

--- a/DisCatSharp/Entities/Guild/ScheduledEvent/DiscordScheduledEventUser.cs
+++ b/DisCatSharp/Entities/Guild/ScheduledEvent/DiscordScheduledEventUser.cs
@@ -102,7 +102,7 @@ namespace DisCatSharp.Entities
 		/// Gets whether the two <see cref="DiscordScheduledEventUser"/> objects are equal.
 		/// </summary>
 		/// <param name="e1">First event to compare.</param>
-		/// <param name="e2">Second ecent to compare.</param>
+		/// <param name="e2">Second event to compare.</param>
 		/// <returns>Whether the two events are equal.</returns>
 		public static bool operator ==(DiscordScheduledEventUser e1, DiscordScheduledEventUser e2)
 		{

--- a/DisCatSharp/Entities/Interaction/Components/Button/DiscordButtonComponent.cs
+++ b/DisCatSharp/Entities/Interaction/Components/Button/DiscordButtonComponent.cs
@@ -85,7 +85,7 @@ namespace DisCatSharp.Entities
 		}
 
 		/// <summary>
-		/// Constucts a new button based on another button.
+		/// Constructs a new button based on another button.
 		/// </summary>
 		/// <param name="other">The button to copy.</param>
 		public DiscordButtonComponent(DiscordButtonComponent other) : this()

--- a/DisCatSharp/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/DisCatSharp/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -30,7 +30,7 @@ using Newtonsoft.Json;
 namespace DisCatSharp.Entities
 {
 	/// <summary>
-	/// Represents a row of components. Acion rows can have up to five components.
+	/// Represents a row of components. Action rows can have up to five components.
 	/// </summary>
 	public sealed class DiscordActionRowComponent : DiscordComponent
 	{

--- a/DisCatSharp/Entities/Interaction/Components/Select/DiscordSelectComponent.cs
+++ b/DisCatSharp/Entities/Interaction/Components/Select/DiscordSelectComponent.cs
@@ -90,8 +90,8 @@ namespace DisCatSharp.Entities
 		/// </summary>
 		/// <param name="customId">The Id to assign to the button. This is sent back when a user presses it.</param>
 		/// <param name="options">Array of options</param>
-		/// <param name="placeholder">Text to show if no option is slected.</param>
-		/// <param name="minOptions">Minmum count of selectable options.</param>
+		/// <param name="placeholder">Text to show if no option is selected.</param>
+		/// <param name="minOptions">Minimum count of selectable options.</param>
 		/// <param name="maxOptions">Maximum count of selectable options.</param>
 		/// <param name="disabled">Whether this button should be initialized as being disabled. User sees a greyed out button that cannot be interacted with.</param>
 		public DiscordSelectComponent(string customId, string placeholder, IEnumerable<DiscordSelectComponentOption> options, int minOptions = 1, int maxOptions = 1, bool disabled = false) : this()

--- a/DisCatSharp/Entities/Interaction/Components/Text/DiscordTextComponent.cs
+++ b/DisCatSharp/Entities/Interaction/Components/Text/DiscordTextComponent.cs
@@ -69,7 +69,7 @@ namespace DisCatSharp.Entities
 		[JsonProperty("max_length", NullValueHandling = NullValueHandling.Ignore)]
 		public int? MaxLength { get; internal set; }
 
-		// NOTE: Probably will be introdruced in future
+		// NOTE: Probably will be introduced in future
 		/*/// <summary>
         /// Whether this text component can be used.
         /// </summary>

--- a/DisCatSharp/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DisCatSharp/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -43,7 +43,7 @@ namespace DisCatSharp.Entities
 		public bool IsEphemeral { get; set; }
 
 		/// <summary>
-		/// Indicates this message is emphemeral.
+		/// Indicates this message is ephemeral.
 		/// </summary>
 		internal int? Flags
 			=> this.IsEphemeral ? 64 : null;

--- a/DisCatSharp/Entities/Interaction/DiscordInteraction.cs
+++ b/DisCatSharp/Entities/Interaction/DiscordInteraction.cs
@@ -131,7 +131,7 @@ namespace DisCatSharp.Entities
 		/// <summary>
 		/// Gets the original interaction response.
 		/// </summary>
-		/// <returns>The origingal message that was sent. This <b>does not work on ephemeral messages.</b></returns>
+		/// <returns>The original message that was sent. This <b>does not work on ephemeral messages.</b></returns>
 		public Task<DiscordMessage> GetOriginalResponseAsync()
 			=> this.Discord.ApiClient.GetOriginalInteractionResponseAsync(this.Discord.CurrentApplication.Id, this.Token);
 

--- a/DisCatSharp/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DisCatSharp/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -27,12 +27,12 @@ using Newtonsoft.Json;
 namespace DisCatSharp.Entities
 {
 	/// <summary>
-	/// Represants a interactions application command callback data.
+	/// Represents a interactions application command callback data.
 	/// </summary>
 	internal class DiscordInteractionApplicationCommandCallbackData
 	{
 		/// <summary>
-		/// Wheter this message is tts
+		/// Whether this message is text to speech.
 		/// </summary>
 		[JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
 		public bool? IsTts { get; internal set; }
@@ -81,7 +81,7 @@ namespace DisCatSharp.Entities
 	}
 
 	/// <summary>
-	/// Represants a interactions application command callback data.
+	/// Represents a interactions application command callback data.
 	/// </summary>
 	internal class DiscordInteractionApplicationCommandModalCallbackData
 	{

--- a/DisCatSharp/Entities/Invite/DiscordInvite.cs
+++ b/DisCatSharp/Entities/Invite/DiscordInvite.cs
@@ -35,7 +35,7 @@ namespace DisCatSharp.Entities
 	public class DiscordInvite
 	{
 		/// <summary>
-		/// Gets the base cloent.
+		/// Gets the base client.
 		/// </summary>
 		internal BaseDiscordClient Discord { get; set; }
 

--- a/DisCatSharp/Entities/Message/DiscordMentions.cs
+++ b/DisCatSharp/Entities/Message/DiscordMentions.cs
@@ -29,7 +29,7 @@ using Newtonsoft.Json;
 namespace DisCatSharp.Entities
 {
 	/// <summary>
-	/// Handles mentionables
+	/// Handles mentionables.
 	/// </summary>
 	internal class DiscordMentions
 	{

--- a/DisCatSharp/Entities/Thread/DiscordThreadChannel.cs
+++ b/DisCatSharp/Entities/Thread/DiscordThreadChannel.cs
@@ -345,7 +345,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public new Task<DiscordMessage> SendMessageAsync(string content) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-thread channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -359,7 +359,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public new Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-thread channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, null, new[] { embed }, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -374,7 +374,7 @@ namespace DisCatSharp.Entities
 		/// <exception cref="DisCatSharp.Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
 		/// <exception cref="DisCatSharp.Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
 		public new Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed) =>
-			!this.IsWriteable()
+			!this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-thread channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, content, new[] { embed }, sticker: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
@@ -404,7 +404,7 @@ namespace DisCatSharp.Entities
 			var builder = new DiscordMessageBuilder();
 			action(builder);
 
-			return !this.IsWriteable()
+			return !this.IsWritable()
 				? throw new ArgumentException("Cannot send a text message to a non-text channel.")
 				: this.Discord.ApiClient.CreateMessageAsync(this.Id, builder);
 		}
@@ -590,16 +590,13 @@ namespace DisCatSharp.Entities
 		/// </summary>
 		/// <returns>String representation of this thread.</returns>
 		public override string ToString()
-		{
-			var threadchannel = (object)this.Type switch
-			{
-				ChannelType.NewsThread => $"News thread {this.Name} ({this.Id})",
-				ChannelType.PublicThread => $"Thread {this.Name} ({this.Id})",
-				ChannelType.PrivateThread => $"Private thread {this.Name} ({this.Id})",
-				_ => $"Thread {this.Name} ({this.Id})",
-			};
-			return threadchannel;
-		}
+			=> this.Type switch
+				{
+					ChannelType.NewsThread => $"News thread {this.Name} ({this.Id})",
+					ChannelType.PublicThread => $"Thread {this.Name} ({this.Id})",
+					ChannelType.PrivateThread => $"Private thread {this.Name} ({this.Id})",
+					_ => $"Thread {this.Name} ({this.Id})",
+				};
 		#endregion
 
 		/// <summary>

--- a/DisCatSharp/Entities/User/DiscordActivity.cs
+++ b/DisCatSharp/Entities/User/DiscordActivity.cs
@@ -350,7 +350,7 @@ namespace DisCatSharp.Entities
 		public DiscordAsset LargeImage { get; internal set; }
 
 		/// <summary>
-		/// Gets the hovertext for large image.
+		/// Gets the hover text for large image.
 		/// </summary>
 		public string LargeImageText { get; internal set; }
 
@@ -360,7 +360,7 @@ namespace DisCatSharp.Entities
 		public DiscordAsset SmallImage { get; internal set; }
 
 		/// <summary>
-		/// Gets the hovertext for small image.
+		/// Gets the hover text for small image.
 		/// </summary>
 		public string SmallImageText { get; internal set; }
 

--- a/DisCatSharp/Enums/Channel/DirectoryCategory.cs
+++ b/DisCatSharp/Enums/Channel/DirectoryCategory.cs
@@ -23,7 +23,7 @@
 namespace DisCatSharp
 {
 	/// <summary>
-	/// Represents a directory entrys primary category type.
+	/// Represents a directory entries primary category type.
 	/// </summary>
 	public enum DirectoryCategory : int
 	{

--- a/DisCatSharp/Enums/Channel/OverwriteType.cs
+++ b/DisCatSharp/Enums/Channel/OverwriteType.cs
@@ -23,7 +23,7 @@
 namespace DisCatSharp
 {
 	/// <summary>
-	/// Represents a channelpermissions overwrite's type.
+	/// Represents a channel permission overwrite's type.
 	/// </summary>
 	public enum OverwriteType : int
 	{

--- a/DisCatSharp/Enums/Discord/DiscordDomain.cs
+++ b/DisCatSharp/Enums/Discord/DiscordDomain.cs
@@ -33,7 +33,7 @@ namespace DisCatSharp.Enums
 		/// <summary>
 		/// dis.gd
 		/// </summary>
-		[DomainHelp("Marketing URL shortner", "dis.gd")]
+		[DomainHelp("Marketing URL shortener", "dis.gd")]
 		DiscordMarketing = 1,
 
 		/// <summary>

--- a/DisCatSharp/Enums/Discord/DiscordShortlink.cs
+++ b/DisCatSharp/Enums/Discord/DiscordShortlink.cs
@@ -20,21 +20,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+
 namespace DisCatSharp.Enums
 {
 	/// <summary>
-	/// Discord short links
+	/// Discord short links.
 	/// </summary>
-	public class DiscordShortlink
+	public static class DiscordShortlink
 	{
-		public string Support = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/support";
-		public string TrustAndSafety = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/request";
-		public string Contact = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/contact";
-		public string BugReport = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/bugreport";
-		public string TranslationError = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/lang-feedback";
-		public string Status = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/status";
-		public string Terms = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/terms";
-		public string Guidlines = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/guidelines";
-		public string Moderation = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/moderation";
+		public static readonly string Support = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/support";
+		public static readonly string TrustAndSafety = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/request";
+		public static readonly string Contact = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/contact";
+		public static readonly string BugReport = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/bugreport";
+		public static readonly string TranslationError = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/lang-feedback";
+		public static readonly string Status = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/status";
+		public static readonly string Terms = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/terms";
+		public static readonly string Guidelines = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/guidelines";
+		public static readonly string Moderation = $"{DiscordDomain.GetDomain(CoreDomain.DiscordMarketing).Url}/moderation";
 	}
 }

--- a/DisCatSharp/Enums/Guild/NsfwLevel.cs
+++ b/DisCatSharp/Enums/Guild/NsfwLevel.cs
@@ -24,7 +24,7 @@
 namespace DisCatSharp
 {
 	/// <summary>
-	/// Represents a guild's conetent level.
+	/// Represents a guild's content level.
 	/// </summary>
 	public enum NsfwLevel
 	{

--- a/DisCatSharp/Enums/Guild/PriceTierType.cs
+++ b/DisCatSharp/Enums/Guild/PriceTierType.cs
@@ -28,7 +28,7 @@ namespace DisCatSharp
 	public enum PriceTierType : int
 	{
 		/// <summary>
-		/// Indicates that this is a role subscriotion.
+		/// Indicates that this is a role subscription.
 		/// </summary>
 		GuildRoleSubscriptions = 1
 	}

--- a/DisCatSharp/Enums/Message/MessageType.cs
+++ b/DisCatSharp/Enums/Message/MessageType.cs
@@ -58,7 +58,7 @@ namespace DisCatSharp
 		ChannelIconChange = 5,
 
 		/// <summary>
-		/// Message indiciating a user pinned a message to a channel.
+		/// Message indicating a user pinned a message to a channel.
 		/// </summary>
 		ChannelPinnedMessage = 6,
 
@@ -103,7 +103,7 @@ namespace DisCatSharp
 		GuildDiscoveryDisqualified = 14,
 
 		/// <summary>
-		/// Message indicating a guild was readded to guild discovery.
+		/// Message indicating a guild was re-added to guild discovery.
 		/// </summary>
 		GuildDiscoveryRequalified = 15,
 

--- a/DisCatSharp/Enums/ScheduledEvent/ScheduledEventPrivacyLevel.cs
+++ b/DisCatSharp/Enums/ScheduledEvent/ScheduledEventPrivacyLevel.cs
@@ -33,7 +33,7 @@ namespace DisCatSharp
 		Public = 1,
 
 		/// <summary>
-		/// Indicates that the the guild scheduled event is only accessable to guild members.
+		/// Indicates that the the guild scheduled event is only accessible to guild members.
 		/// </summary>
 		GuildOnly = 2
 	}

--- a/DisCatSharp/Enums/Thread/ThreadAutoArchiveDuration.cs
+++ b/DisCatSharp/Enums/Thread/ThreadAutoArchiveDuration.cs
@@ -33,7 +33,7 @@ namespace DisCatSharp
 		OneHour = 60,
 
 		/// <summary>
-		/// Indicates that the thread will be auto archived after one day / twentyfour hours.
+		/// Indicates that the thread will be auto archived after one day / 24 hours.
 		/// </summary>
 		OneDay = 1440,
 

--- a/DisCatSharp/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
+++ b/DisCatSharp/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
@@ -63,22 +63,22 @@ namespace DisCatSharp.EventArgs
 		public string NicknameBefore { get; internal set; }
 
 		/// <summary>
-		/// Gets whether the member had passed membership screening before the update
+		/// Gets whether the member had passed membership screening before the update.
 		/// </summary>
 		public bool? PendingBefore { get; internal set; }
 
 		/// <summary>
-		/// Gets whether the member had passed membership screening after the update
+		/// Gets whether the member had passed membership screening after the update.
 		/// </summary>
 		public bool? PendingAfter { get; internal set; }
 
 		/// <summary>
-		/// Gets whether the member is timeouted before the update
+		/// Gets whether the member is timed out before the update.
 		/// </summary>
 		public DateTimeOffset? TimeoutBefore { get; internal set; }
 
 		/// <summary>
-		/// Gets whether the member is timeouted after the update
+		/// Gets whether the member is timed out after the update.
 		/// </summary>
 		public DateTimeOffset? TimeoutAfter { get; internal set; }
 

--- a/DisCatSharp/EventArgs/Interaction/ContextMenuInteractionCreateEventArgs.cs
+++ b/DisCatSharp/EventArgs/Interaction/ContextMenuInteractionCreateEventArgs.cs
@@ -38,7 +38,7 @@ namespace DisCatSharp.EventArgs
 		public ApplicationCommandType Type { get; internal set; }
 
 		/// <summary>
-		/// The user that invoked this interaction. Can be casted to a member if this was on a guild.
+		/// The user that invoked this interaction. Can be cast to a member if this was on a guild.
 		/// </summary>
 		public DiscordUser User => this.Interaction.User;
 

--- a/DisCatSharp/EventArgs/ZombiedEventArgs.cs
+++ b/DisCatSharp/EventArgs/ZombiedEventArgs.cs
@@ -30,12 +30,12 @@ namespace DisCatSharp.EventArgs
 	public class ZombiedEventArgs : DiscordEventArgs
 	{
 		/// <summary>
-		/// Gets how many heartbeat failures have occured.
+		/// Gets how many heartbeat failures have occurred.
 		/// </summary>
 		public int Failures { get; internal set; }
 
 		/// <summary>
-		/// Gets whether the zombie event occured whilst guilds are downloading.
+		/// Gets whether the zombie event occurred whilst guilds are downloading.
 		/// </summary>
 		public bool GuildDownloadCompleted { get; internal set; }
 

--- a/DisCatSharp/Formatter.cs
+++ b/DisCatSharp/Formatter.cs
@@ -89,7 +89,7 @@ namespace DisCatSharp
 		/// <summary>
 		/// Creates bold text.
 		/// </summary>
-		/// <param name="content">Text to bolden.</param>
+		/// <param name="content">Text to embolden.</param>
 		/// <returns>Formatted text.</returns>
 		public static string Bold(string content)
 			=> $"**{content}**";
@@ -105,7 +105,7 @@ namespace DisCatSharp
 		/// <summary>
 		/// Creates spoiler from text.
 		/// </summary>
-		/// <param name="content">Text to spoilerize.</param>
+		/// <param name="content">Text to spoiler.</param>
 		/// <returns>Formatted text.</returns>
 		public static string Spoiler(string content)
 			=> $"||{content}||";

--- a/DisCatSharp/Internals.cs
+++ b/DisCatSharp/Internals.cs
@@ -77,7 +77,7 @@ namespace DisCatSharp
 		/// Whether users can write the <see cref="DiscordChannel"/>.
 		/// </summary>
 		/// <param name="channel">The channel.</param>
-		internal static bool IsWriteable(this DiscordChannel channel) => channel.Type == ChannelType.PublicThread || channel.Type == ChannelType.PrivateThread || channel.Type == ChannelType.NewsThread || channel.Type == ChannelType.Text || channel.Type == ChannelType.News || channel.Type == ChannelType.Group || channel.Type == ChannelType.Private || channel.Type == ChannelType.Voice;
+		internal static bool IsWritable(this DiscordChannel channel) => channel.Type == ChannelType.PublicThread || channel.Type == ChannelType.PrivateThread || channel.Type == ChannelType.NewsThread || channel.Type == ChannelType.Text || channel.Type == ChannelType.News || channel.Type == ChannelType.Group || channel.Type == ChannelType.Private || channel.Type == ChannelType.Voice;
 
 		/// <summary>
 		/// Whether the <see cref="DiscordChannel"/> is moveable in a parent.

--- a/DisCatSharp/Logging/DefaultLogger.cs
+++ b/DisCatSharp/Logging/DefaultLogger.cs
@@ -115,7 +115,7 @@ namespace DisCatSharp
 					LogLevel.Information => "[Info ] ",
 					LogLevel.Warning => "[Warn ] ",
 					LogLevel.Error => "[Error] ",
-					LogLevel.Critical => "[Crit ]",
+					LogLevel.Critical => "[Critical ]",
 					LogLevel.None => "[None ] ",
 					_ => "[?????] "
 				});

--- a/DisCatSharp/Logging/LoggerEvents.cs
+++ b/DisCatSharp/Logging/LoggerEvents.cs
@@ -110,7 +110,7 @@ namespace DisCatSharp
 		public static EventId RatelimitDiag { get; } = new(115, nameof(RatelimitDiag));
 
 		/// <summary>
-		/// Events emitted when a ratelimit is exhausted and a request is preemtively blocked.
+		/// Events emitted when a ratelimit is exhausted and a request is preemptively blocked.
 		/// </summary>
 		public static EventId RatelimitPreemptive { get; } = new(116, nameof(RatelimitPreemptive));
 

--- a/DisCatSharp/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DisCatSharp/Net/Abstractions/AuditLogAbstractions.cs
@@ -102,258 +102,258 @@ namespace DisCatSharp.Net.Abstractions
 	}
 
 	/// <summary>
-	/// Represents a audit log thread metadata
+	/// Represents a audit log thread metadata.
 	/// </summary>
 	internal sealed class AuditLogThreadMetadata
 	{
 		/// <summary>
-		/// Gets whether the thread is archived
+		/// Gets whether the thread is archived.
 		/// </summary>
 		[JsonProperty("archived")]
 		public bool Archived { get; set; }
 
 		/// <summary>
-		/// Gets the threads archive timestamp
+		/// Gets the threads archive timestamp.
 		/// </summary>
 		[JsonProperty("archive_timestamp", NullValueHandling = NullValueHandling.Ignore)]
 		public string ArchiveTimestamp { get; set; }
 
 		/// <summary>
-		/// Gets the threads auto archive duration
+		/// Gets the threads auto archive duration.
 		/// </summary>
 		[JsonProperty("auto_archive_duration")]
 		public int AutoArchiveDuration { get; set; }
 
 		/// <summary>
-		/// Gets whether the thread is lockeed
+		/// Gets whether the thread is locked.
 		/// </summary>
 		[JsonProperty("locked")]
 		public bool Locked { get; set; }
 	}
 
 	/// <summary>
-	/// Represents a audit log thread
+	/// Represents a audit log thread.
 	/// </summary>
 	internal sealed class AuditLogThread
 	{
 		/// <summary>
-		/// Gets the thread id
+		/// Gets the thread id.
 		/// </summary>
 		[JsonProperty("id")]
 		public ulong Id { get; set; }
 
 		/// <summary>
-		/// Gets the thread guild id
+		/// Gets the thread guild id.
 		/// </summary>
 		[JsonProperty("guild_id")]
 		public ulong GuildId { get; set; }
 
 		/// <summary>
-		/// Gets the thread parent channel id
+		/// Gets the thread parent channel id.
 		/// </summary>
 		[JsonProperty("parent_id")]
 		public ulong ParentId { get; set; }
 
 		/// <summary>
-		/// Gets the thread owner id
+		/// Gets the thread owner id.
 		/// </summary>
 		[JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
 		public ulong? OwnerId { get; set; }
 
 		/// <summary>
-		/// Gets the thread type
+		/// Gets the thread type.
 		/// </summary>
 		[JsonProperty("type")]
 		public ChannelType Type { get; set; }
 
 		/// <summary>
-		/// Gets the thread name
+		/// Gets the thread name.
 		/// </summary>
 		[JsonProperty("name")]
 		public string Name { get; set; }
 
 		/// <summary>
-		/// Gets the thread last message id
+		/// Gets the thread last message id.
 		/// </summary>
 		[JsonProperty("last_message_id", NullValueHandling = NullValueHandling.Ignore)]
 		public ulong? LastMessageId { get; set; }
 
 		/// <summary>
-		/// Gets the thread metadata
+		/// Gets the thread metadata.
 		/// </summary>
 		[JsonProperty("thread_metadata")]
 		public AuditLogThreadMetadata Metadata { get; set; }
 
 		/// <summary>
-		/// Gets the thread approximate message count
+		/// Gets the thread approximate message count.
 		/// </summary>
 		[JsonProperty("message_count", NullValueHandling = NullValueHandling.Ignore)]
 		public int? MessageCount { get; set; }
 
 		/// <summary>
-		/// Gets the thread member count
+		/// Gets the thread member count.
 		/// </summary>
 		[JsonProperty("member_count", NullValueHandling = NullValueHandling.Ignore)]
 		public int? MemberCount { get; set; }
 
 		/// <summary>
-		/// Gets the thread rate limit per user
+		/// Gets the thread rate limit per user.
 		/// </summary>
 		[JsonProperty("rate_limit_per_user", NullValueHandling = NullValueHandling.Ignore)]
 		public int? RateLimitPerUser { get; set; }
 	}
 
 	/// <summary>
-	/// Represents a audit log scheduled event
+	/// Represents a audit log scheduled event.
 	/// </summary>
 	internal sealed class AuditLogGuildScheduledEvent
 	{
 		/// <summary>
-		/// Gets the scheduled event id
+		/// Gets the scheduled event id.
 		/// </summary>
 		[JsonProperty("id")]
 		public ulong Id { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event guild id
+		/// Gets the scheduled event guild id.
 		/// </summary>
 		[JsonProperty("guild_id")]
 		public ulong GuildId { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event channel id
+		/// Gets the scheduled event channel id.
 		/// </summary>
 		[JsonProperty("channel_id")]
 		public ulong ChannelId { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event creator id
+		/// Gets the scheduled event creator id.
 		/// </summary>
 		[JsonProperty("creator_id")]
 		public ulong CreatorId { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event name
+		/// Gets the scheduled event name.
 		/// </summary>
 		[JsonProperty("name")]
 		public string Name { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event description
+		/// Gets the scheduled event description.
 		/// </summary>
 		[JsonProperty("description")]
 		public string Description { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event image
+		/// Gets the scheduled event image.
 		/// </summary>
 		[JsonProperty("image", NullValueHandling = NullValueHandling.Ignore)]
 		public string Image { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event scheduled start time
+		/// Gets the scheduled event scheduled start time.
 		/// </summary>
 		[JsonProperty("scheduled_start_time")]
 		public string ScheduledStartTime;
 
 		/// <summary>
-		/// Gets the scheduled event scheduled end time
+		/// Gets the scheduled event scheduled end time.
 		/// </summary>
 		[JsonProperty("scheduled_end_time")]
 		public string ScheduledEndTime { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event privacy level
+		/// Gets the scheduled event privacy level.
 		/// </summary>
 		[JsonProperty("privacy_level")]
 		public ScheduledEventPrivacyLevel PrivacyLevel { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event status
+		/// Gets the scheduled event status.
 		/// </summary>
 		[JsonProperty("status")]
 		public ScheduledEventStatus Status { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event entity type
+		/// Gets the scheduled event entity type.
 		/// </summary>
 		[JsonProperty("entity_type")]
 		public ScheduledEventEntityType EntityType { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event entity id
+		/// Gets the scheduled event entity id.
 		/// </summary>
 		[JsonProperty("entity_id")]
 		public ulong EntityId { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event entity metadata
+		/// Gets the scheduled event entity metadata.
 		/// </summary>
 		[JsonProperty("entity_metadata")]
 		public AuditLogGuildScheduledEventEntityMetadata EntityMetadata { get; set; }
 
 		/// <summary>
-		/// Gets the scheduled event sku ids
+		/// Gets the scheduled event sku ids.
 		/// </summary>
 		[JsonProperty("sku_ids")]
 		public List<ulong> SkuIds { get; set; }
 	}
 
 	/// <summary>
-	/// Represents a audit log scheduled event entity metadata
+	/// Represents a audit log scheduled event entity metadata.
 	/// </summary>
 	internal sealed class AuditLogGuildScheduledEventEntityMetadata
 	{
 		/// <summary>
-		/// Gets the scheduled events external location
+		/// Gets the scheduled events external location.
 		/// </summary>
 		[JsonProperty("location")]
 		public string Location { get; set; }
 	}
 
 	/// <summary>
-	/// Represents a audit log integration account
+	/// Represents a audit log integration account.
 	/// </summary>
 	internal sealed class AuditLogIntegrationAccount
 	{
 		/// <summary>
-		/// Gets the account id
+		/// Gets the account id.
 		/// </summary>
 		[JsonProperty("id")]
 		public string Id { get; set; }
 
 		/// <summary>
-		/// Gets the account name
+		/// Gets the account name.
 		/// </summary>
 		[JsonProperty("name")]
 		public string Name { get; set; }
 	}
 
 	/// <summary>
-	/// Represents a audit log integration
+	/// Represents a audit log integration.
 	/// </summary>
 	internal sealed class AuditLogIntegration
 	{
 		/// <summary>
-		/// Gets the integration id
+		/// Gets the integration id.
 		/// </summary>
 		[JsonProperty("id")]
 		public ulong Id { get; set; }
 
 		/// <summary>
-		/// Gets the integration type
+		/// Gets the integration type.
 		/// </summary>
 		[JsonProperty("type")]
 		public string Type { get; set; }
 
 		/// <summary>
-		/// Gets the integration name
+		/// Gets the integration name.
 		/// </summary>
 		[JsonProperty("name")]
 		public string Name { get; set; }
 
 		/// <summary>
-		/// Gets the integration account
+		/// Gets the integration account.
 		/// </summary>
 		[JsonProperty("account")]
 		public AuditLogIntegrationAccount Account { get; set; }
@@ -568,7 +568,7 @@ namespace DisCatSharp.Net.Abstractions
 		/*
         /// <summary>
         /// Gets or sets the application commands.
-        /// Releated to Permissions V2.
+        /// Related to Permissions V2.
         /// </summary>
         [JsonProperty("application_commands")]
         public IEnumerable<AuditLogApplicationCommand> ApplicationCommands { get; set; }

--- a/DisCatSharp/Net/Abstractions/ReadyPayload.cs
+++ b/DisCatSharp/Net/Abstractions/ReadyPayload.cs
@@ -34,7 +34,7 @@ namespace DisCatSharp.Net.Abstractions
 	internal class ReadyPayload
 	{
 		/// <summary>
-		/// Gets the gateway version the client is connectected to.
+		/// Gets the gateway version the client is connected to.
 		/// </summary>
 		[JsonProperty("v")]
 		public int GatewayVersion { get; private set; }

--- a/DisCatSharp/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DisCatSharp/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -497,7 +497,7 @@ namespace DisCatSharp.Net.Abstractions
 		public Optional<int?> PerUserRateLimit { get; set; }
 
 		/// <summary>
-		/// Gets or sets the threads's invitable state.
+		/// Gets or sets the thread's invitable state.
 		/// </summary>
 		[JsonProperty("invitable", NullValueHandling = NullValueHandling.Ignore)]
 		public Optional<bool?> Invitable { internal get; set; }

--- a/DisCatSharp/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DisCatSharp/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -166,7 +166,7 @@ namespace DisCatSharp.Net.Abstractions
 		/// <summary>
 		/// Gets or sets the discovery splash base64.
 		/// </summary>
-		[JsonProperty("discorvery_splash")]
+		[JsonProperty("discovery_splash")]
 		public Optional<string> DiscoverySplashBase64 { get; set; }
 
 		/// <summary>

--- a/DisCatSharp/Net/Abstractions/Rest/RestGuildScheduledEventPayloads.cs
+++ b/DisCatSharp/Net/Abstractions/Rest/RestGuildScheduledEventPayloads.cs
@@ -91,7 +91,7 @@ namespace DisCatSharp.Net.Abstractions
 	/// <summary>
 	/// The rest guild scheduled event modify payload.
 	/// </summary>
-	internal class RestGuildSheduledEventModifyPayload
+	internal class RestGuildScheduledEventModifyPayload
 	{
 		/// <summary>
 		/// Gets or sets the channel id.

--- a/DisCatSharp/Net/Abstractions/Rest/RestGuildScheduledEventPayloads.cs
+++ b/DisCatSharp/Net/Abstractions/Rest/RestGuildScheduledEventPayloads.cs
@@ -29,7 +29,7 @@ using Newtonsoft.Json;
 namespace DisCatSharp.Net.Abstractions
 {
 	/// <summary>
-	/// The rest guild sheduled event create payload.
+	/// The rest guild scheduled event create payload.
 	/// </summary>
 	internal class RestGuildScheduledEventCreatePayload
 	{
@@ -89,7 +89,7 @@ namespace DisCatSharp.Net.Abstractions
 	}
 
 	/// <summary>
-	/// The rest guild sheduled event modify payload.
+	/// The rest guild scheduled event modify payload.
 	/// </summary>
 	internal class RestGuildSheduledEventModifyPayload
 	{

--- a/DisCatSharp/Net/Abstractions/Transport/TransportActivity.cs
+++ b/DisCatSharp/Net/Abstractions/Transport/TransportActivity.cs
@@ -55,7 +55,7 @@ namespace DisCatSharp.Net.Abstractions
 		public string StreamUrl { get; internal set; }
 
 		/// <summary>
-		/// Gets or sets the livesteam type.
+		/// Gets or sets the livestream type.
 		/// </summary>
 		[JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
 		public ActivityType ActivityType { get; internal set; }
@@ -157,7 +157,7 @@ namespace DisCatSharp.Net.Abstractions
 		public string SessionId { get; internal set; }
 
 		/// <summary>
-		/// Gets or sets infromation about current game's timestamps.
+		/// Gets or sets information about current game's timestamps.
 		///
 		/// This is a component of the rich presence, and, as such, can only be used by regular users.
 		/// </summary>

--- a/DisCatSharp/Net/Abstractions/Transport/TransportApplication.cs
+++ b/DisCatSharp/Net/Abstractions/Transport/TransportApplication.cs
@@ -64,7 +64,7 @@ namespace DisCatSharp.Net.Abstractions
 		public string Summary { get; set; }
 
 		/// <summary>
-		/// Wwhether the bot is public.
+		/// Whether the bot is public.
 		/// </summary>
 		[JsonProperty("bot_public", NullValueHandling = NullValueHandling.Include)]
 		public bool IsPublicBot { get; set; }

--- a/DisCatSharp/Net/Models/ChannelEditModel.cs
+++ b/DisCatSharp/Net/Models/ChannelEditModel.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -69,11 +70,14 @@ namespace DisCatSharp.Net.Models
 		/// </summary>
 		public int? Bitrate { internal get; set; }
 
+		[Obsolete("Use properly capitalized UserLimit property")]
+		public int? Userlimit { set => this.UserLimit = value; }
+
 		/// <summary>
 		/// <para>Sets the voice channel's new user limit.</para>
 		/// <para>Setting this to 0 will disable the user limit.</para>
 		/// </summary>
-		public int? Userlimit { internal get; set; }
+		public int? UserLimit { internal get; set; }
 
 		/// <summary>
 		/// <para>Sets the channel's new slow mode timeout.</para>

--- a/DisCatSharp/Net/Models/GuildEditModel.cs
+++ b/DisCatSharp/Net/Models/GuildEditModel.cs
@@ -117,7 +117,7 @@ namespace DisCatSharp.Net.Models
 		public Optional<Stream> Banner { get; set; }
 
 		/// <summary>
-		/// The new discorvery splash image of the guild
+		/// The new discovery splash image of the guild
 		/// </summary>
 		public Optional<Stream> DiscoverySplash { get; set; }
 

--- a/DisCatSharp/Net/Models/ThreadEditModel.cs
+++ b/DisCatSharp/Net/Models/ThreadEditModel.cs
@@ -30,32 +30,32 @@ namespace DisCatSharp.Net.Models
 	public class ThreadEditModel : BaseEditModel
 	{
 		/// <summary>
-		/// Sets the threads's new name.
+		/// Sets the thread's new name.
 		/// </summary>
 		public string Name { internal get; set; }
 
 		/// <summary>
-		/// Sets the threads's locked state.
+		/// Sets the thread's locked state.
 		/// </summary>
 		public Optional<bool?> Locked { internal get; set; }
 
 		/// <summary>
-		/// Sets the threads's archived state.
+		/// Sets the thread's archived state.
 		/// </summary>
 		public Optional<bool?> Archived { internal get; set; }
 
 		/// <summary>
-		/// Sets the threads's auto archive duration.
+		/// Sets the thread's auto archive duration.
 		/// </summary>
 		public Optional<ThreadAutoArchiveDuration?> AutoArchiveDuration { internal get; set; }
 
 		/// <summary>
-		/// Sets the threads's new user rate limit.
+		/// Sets the thread's new user rate limit.
 		/// </summary>
 		public Optional<int?> PerUserRateLimit { internal get; set; }
 
 		/// <summary>
-		/// Sets the threads's invitable state.
+		/// Sets the thread's invitable state.
 		/// </summary>
 		public Optional<bool?> Invitable { internal get; set; }
 

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -1436,16 +1436,16 @@ namespace DisCatSharp.Net
 		}
 
 		/// <summary>
-		/// Gets the users who RSVP'd to a sheduled event.
+		/// Gets the users who RSVP'd to a scheduled event.
 		/// Optional with member objects.
 		/// This endpoint is paginated.
 		/// </summary>
 		/// <param name="guildId">The guild_id.</param>
-		/// <param name="scheduledEventId">The sheduled event id.</param>
+		/// <param name="scheduledEventId">The scheduled event id.</param>
 		/// <param name="limit">The limit how many users to receive from the event.</param>
 		/// <param name="before">Get results before the given id.</param>
 		/// <param name="after">Get results after the given id.</param>
-		/// <param name="withMember">Wether to include guild member data. attaches guild_member property to the user object.</param>
+		/// <param name="withMember">Whether to include guild member data. attaches guild_member property to the user object.</param>
 		internal async Task<IReadOnlyDictionary<ulong, DiscordScheduledEventUser>> GetGuildScheduledEventRspvUsersAsync(ulong guildId, ulong scheduledEventId, int? limit, ulong? before, ulong? after, bool? withMember)
 		{
 			var urlparams = new Dictionary<string, string>();

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -423,7 +423,7 @@ namespace DisCatSharp.Net
 		/// <param name="rulesChannelId">The rules channel id.</param>
 		/// <param name="description">The description.</param>
 		/// <param name="bannerb64">The banner base64.</param>
-		/// <param name="discorverySplashb64">The discovery base64.</param>
+		/// <param name="discoverySplashb64">The discovery base64.</param>
 		/// <param name="preferredLocale">The preferred locale.</param>
 		/// <param name="premiumProgressBarEnabled">Whether the premium progress bar should be enabled.</param>
 		/// <param name="reason">The reason.</param>
@@ -433,7 +433,7 @@ namespace DisCatSharp.Net
 			Optional<int> afkTimeout, Optional<string> iconb64, Optional<ulong> ownerId, Optional<string> splashb64,
 			Optional<ulong?> systemChannelId, Optional<SystemChannelFlags> systemChannelFlags,
 			Optional<ulong?> publicUpdatesChannelId, Optional<ulong?> rulesChannelId, Optional<string> description,
-			Optional<string> bannerb64, Optional<string> discorverySplashb64, Optional<string> preferredLocale, Optional<bool> premiumProgressBarEnabled, string reason)
+			Optional<string> bannerb64, Optional<string> discoverySplashb64, Optional<string> preferredLocale, Optional<bool> premiumProgressBarEnabled, string reason)
 		{
 			var pld = new RestGuildModifyPayload
 			{
@@ -447,7 +447,7 @@ namespace DisCatSharp.Net
 				IconBase64 = iconb64,
 				SplashBase64 = splashb64,
 				BannerBase64 = bannerb64,
-				DiscoverySplashBase64 = discorverySplashb64,
+				DiscoverySplashBase64 = discoverySplashb64,
 				OwnerId = ownerId,
 				SystemChannelId = systemChannelId,
 				SystemChannelFlags = systemChannelFlags,
@@ -576,7 +576,7 @@ namespace DisCatSharp.Net
 			if (deleteMessageDays < 0 || deleteMessageDays > 7)
 				throw new ArgumentException("Delete message days must be a number between 0 and 7.", nameof(deleteMessageDays));
 
-			var urlparams = new Dictionary<string, string>
+			var urlParams = new Dictionary<string, string>
 			{
 				["delete_message_days"] = deleteMessageDays.ToString(CultureInfo.InvariantCulture)
 			};
@@ -588,7 +588,7 @@ namespace DisCatSharp.Net
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new {guild_id = guildId, user_id = userId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams), this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlParams), this.Discord.Configuration);
 			return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, headers);
 		}
 
@@ -667,16 +667,16 @@ namespace DisCatSharp.Net
 
 		internal async Task<IReadOnlyList<TransportMember>> ListGuildMembersAsync(ulong guildId, int? limit, ulong? after)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (limit != null && limit > 0)
-				urlparams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
 			if (after != null)
-				urlparams["after"] = after.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["after"] = after.Value.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var membersRaw = JsonConvert.DeserializeObject<List<TransportMember>>(res.Response);
@@ -817,23 +817,23 @@ namespace DisCatSharp.Net
 
 		internal async Task<AuditLog> GetAuditLogsAsync(ulong guildId, int limit, ulong? after, ulong? before, ulong? responsible, int? actionType)
 		{
-			var urlparams = new Dictionary<string, string>
+			var urlParams = new Dictionary<string, string>
 			{
 				["limit"] = limit.ToString(CultureInfo.InvariantCulture)
 			};
 			if (after != null)
-				urlparams["after"] = after?.ToString(CultureInfo.InvariantCulture);
+				urlParams["after"] = after?.ToString(CultureInfo.InvariantCulture);
 			if (before != null)
-				urlparams["before"] = before?.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before?.ToString(CultureInfo.InvariantCulture);
 			if (responsible != null)
-				urlparams["user_id"] = responsible?.ToString(CultureInfo.InvariantCulture);
+				urlParams["user_id"] = responsible?.ToString(CultureInfo.InvariantCulture);
 			if (actionType != null)
-				urlparams["action_type"] = actionType?.ToString(CultureInfo.InvariantCulture);
+				urlParams["action_type"] = actionType?.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.AUDIT_LOGS}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var auditLogDataRaw = JsonConvert.DeserializeObject<AuditLog>(res.Response);
@@ -1242,7 +1242,7 @@ namespace DisCatSharp.Net
 		/// </summary>
 		internal async Task<DiscordScheduledEvent> ModifyGuildScheduledEventAsync(ulong guildId, ulong scheduledEventId, Optional<ulong?> channelId, Optional<DiscordScheduledEventEntityMetadata> metadata, Optional<string> name, Optional<DateTimeOffset> scheduledStartTime, Optional<DateTimeOffset> scheduledEndTime, Optional<string> description, Optional<ScheduledEventEntityType> type, Optional<ScheduledEventStatus> status, Optional<string> coverb64, string reason = null)
 		{
-			var pld = new RestGuildSheduledEventModifyPayload
+			var pld = new RestGuildScheduledEventModifyPayload
 			{
 				ChannelId = channelId,
 				EntityMetadata = metadata,
@@ -1294,7 +1294,7 @@ namespace DisCatSharp.Net
 		/// </summary>
 		internal async Task<DiscordScheduledEvent> ModifyGuildScheduledEventStatusAsync(ulong guildId, ulong scheduledEventId, ScheduledEventStatus status, string reason = null)
 		{
-			var pld = new RestGuildSheduledEventModifyPayload
+			var pld = new RestGuildScheduledEventModifyPayload
 			{
 				Status = status
 			};
@@ -1341,14 +1341,14 @@ namespace DisCatSharp.Net
 		/// <param name="withUserCount">Whether to include user count.</param>
 		internal async Task<DiscordScheduledEvent> GetGuildScheduledEventAsync(ulong guildId, ulong scheduledEventId, bool? withUserCount)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (withUserCount.HasValue)
-				urlparams["with_user_count"] = withUserCount?.ToString();
+				urlParams["with_user_count"] = withUserCount?.ToString();
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.SCHEDULED_EVENTS}/:scheduled_event_id";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId, scheduled_event_id = scheduledEventId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
 
@@ -1380,14 +1380,14 @@ namespace DisCatSharp.Net
 		/// <param name="withUserCount">Whether to include the count of users subscribed to the scheduled event.</param>
 		internal async Task<IReadOnlyDictionary<ulong, DiscordScheduledEvent>> ListGuildScheduledEventsAsync(ulong guildId, bool? withUserCount)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (withUserCount.HasValue)
-				urlparams["with_user_count"] = withUserCount?.ToString();
+				urlParams["with_user_count"] = withUserCount?.ToString();
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.SCHEDULED_EVENTS}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
 
 			var events = new Dictionary<ulong, DiscordScheduledEvent>();
@@ -1417,10 +1417,10 @@ namespace DisCatSharp.Net
 		}
 
 		/// <summary>
-		/// Deletes a guild sheduled event.
+		/// Deletes a guild scheduled event.
 		/// </summary>
 		/// <param name="guildId">The guild_id.</param>
-		/// <param name="scheduledEventId">The sheduled event id.</param>
+		/// <param name="scheduledEventId">The scheduled event id.</param>
 		/// <param name="reason">The reason.</param>
 		internal Task DeleteGuildScheduledEventAsync(ulong guildId, ulong scheduledEventId, string reason)
 		{
@@ -1448,20 +1448,20 @@ namespace DisCatSharp.Net
 		/// <param name="withMember">Whether to include guild member data. attaches guild_member property to the user object.</param>
 		internal async Task<IReadOnlyDictionary<ulong, DiscordScheduledEventUser>> GetGuildScheduledEventRspvUsersAsync(ulong guildId, ulong scheduledEventId, int? limit, ulong? before, ulong? after, bool? withMember)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (limit != null && limit > 0)
-				urlparams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
 			if (before != null)
-				urlparams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
 			if (after != null)
-				urlparams["after"] = after.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["after"] = after.Value.ToString(CultureInfo.InvariantCulture);
 			if (withMember != null)
-				urlparams["with_member"] = withMember.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["with_member"] = withMember.Value.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.SCHEDULED_EVENTS}/:scheduled_event_id{Endpoints.USERS}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId, scheduled_event_id = scheduledEventId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var rspvUsers = JsonConvert.DeserializeObject<IEnumerable<DiscordScheduledEventUser>>(res.Response);
@@ -1515,10 +1515,10 @@ namespace DisCatSharp.Net
 
 		internal async Task<DiscordChannel> CreateGuildChannelAsync(ulong guildId, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? userLimit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, VideoQualityMode? qualityMode, string reason)
 		{
-			var restoverwrites = new List<DiscordRestOverwrite>();
+			var restOverwrites = new List<DiscordRestOverwrite>();
 			if (overwrites != null)
 				foreach (var ow in overwrites)
-					restoverwrites.Add(ow.Build());
+					restOverwrites.Add(ow.Build());
 
 			var pld = new RestChannelCreatePayload
 			{
@@ -1528,7 +1528,7 @@ namespace DisCatSharp.Net
 				Topic = topic,
 				Bitrate = bitrate,
 				UserLimit = userLimit,
-				PermissionOverwrites = restoverwrites,
+				PermissionOverwrites = restOverwrites,
 				Nsfw = nsfw,
 				PerUserRateLimit = perUserRateLimit,
 				QualityMode = qualityMode
@@ -1941,20 +1941,20 @@ namespace DisCatSharp.Net
 
 		internal async Task<IReadOnlyList<DiscordMessage>> GetChannelMessagesAsync(ulong channelId, int limit, ulong? before, ulong? after, ulong? around)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (around != null)
-				urlparams["around"] = around?.ToString(CultureInfo.InvariantCulture);
+				urlParams["around"] = around?.ToString(CultureInfo.InvariantCulture);
 			if (before != null)
-				urlparams["before"] = before?.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before?.ToString(CultureInfo.InvariantCulture);
 			if (after != null)
-				urlparams["after"] = after?.ToString(CultureInfo.InvariantCulture);
+				urlParams["after"] = after?.ToString(CultureInfo.InvariantCulture);
 			if (limit > 0)
-				urlparams["limit"] = limit.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {channel_id = channelId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var msgsRaw = JArray.Parse(res.Response);
@@ -2497,14 +2497,14 @@ namespace DisCatSharp.Net
 
 		internal Task RemoveGuildMemberAsync(ulong guildId, ulong userId, string reason)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (reason != null)
-				urlparams["reason"] = reason;
+				urlParams["reason"] = reason;
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new {guild_id = guildId, user_id = userId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams), this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlParams), this.Discord.Configuration);
 			return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
 		}
 
@@ -2684,15 +2684,15 @@ namespace DisCatSharp.Net
 
 		internal async Task<DiscordGuild> GetGuildAsync(ulong guildId, bool? withCounts)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (withCounts.HasValue)
-				urlparams["with_counts"] = withCounts?.ToString();
+				urlParams["with_counts"] = withCounts?.ToString();
 
 			var route = $"{Endpoints.GUILDS}/:guild_id";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id = guildId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
-			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, urlparams).ConfigureAwait(false);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
+			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, urlParams).ConfigureAwait(false);
 
 			var json = JObject.Parse(res.Response);
 			var rawMembers = (JArray)json["members"];
@@ -2838,7 +2838,7 @@ namespace DisCatSharp.Net
 			if (days < 0 || days > 30)
 				throw new ArgumentException("Prune inactivity days must be a number between 0 and 30.", nameof(days));
 
-			var urlparams = new Dictionary<string, string>
+			var urlParams = new Dictionary<string, string>
 			{
 				["days"] = days.ToString(CultureInfo.InvariantCulture)
 			};
@@ -2856,7 +2856,7 @@ namespace DisCatSharp.Net
 
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id = guildId }, out var path);
-			var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlParams)}{sb}", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -2878,7 +2878,7 @@ namespace DisCatSharp.Net
 			if (days < 0 || days > 30)
 				throw new ArgumentException("Prune inactivity days must be a number between 0 and 30.", nameof(days));
 
-			var urlparams = new Dictionary<string, string>
+			var urlParams = new Dictionary<string, string>
 			{
 				["days"] = days.ToString(CultureInfo.InvariantCulture),
 				["compute_prune_count"] = computePruneCount.ToString()
@@ -2902,7 +2902,7 @@ namespace DisCatSharp.Net
 			var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {guild_id = guildId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlParams)}{sb}", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers).ConfigureAwait(false);
 
 			var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -3102,18 +3102,18 @@ namespace DisCatSharp.Net
 
 		internal async Task<DiscordInvite> GetInviteAsync(string inviteCode, bool? withCounts, bool? withExpiration, ulong? guildScheduledEventId)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (withCounts.HasValue)
-				urlparams["with_counts"] = withCounts?.ToString();
+				urlParams["with_counts"] = withCounts?.ToString();
 			if (withExpiration.HasValue)
-				urlparams["with_expiration"] = withExpiration?.ToString();
+				urlParams["with_expiration"] = withExpiration?.ToString();
 			if (guildScheduledEventId.HasValue)
-				urlparams["guild_scheduled_event_id"] = guildScheduledEventId?.ToString();
+				urlParams["guild_scheduled_event_id"] = guildScheduledEventId?.ToString();
 
 			var route = $"{Endpoints.INVITES}/:invite_code";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {invite_code = inviteCode }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -3811,16 +3811,16 @@ namespace DisCatSharp.Net
 
 		internal async Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channelId, ulong messageId, string emoji, ulong? afterId = null, int limit = 25)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (afterId.HasValue)
-				urlparams["after"] = afterId.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["after"] = afterId.Value.ToString(CultureInfo.InvariantCulture);
 
-			urlparams["limit"] = limit.ToString(CultureInfo.InvariantCulture);
+			urlParams["limit"] = limit.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {channel_id = channelId, message_id = messageId, emoji }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams), this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, BuildQueryString(urlParams), this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 			var reactersRaw = JsonConvert.DeserializeObject<IEnumerable<TransportUser>>(res.Response);
@@ -4059,16 +4059,16 @@ namespace DisCatSharp.Net
 		/// <param name="limit">Limit the results.</param>
 		internal async Task<DiscordThreadResult> GetJoinedPrivateArchivedThreadsAsync(ulong channelId, ulong? before, int? limit)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (before != null)
-				urlparams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
 			if (limit != null && limit > 0)
-				urlparams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.USERS}{Endpoints.ME}{Endpoints.THREADS}{Endpoints.THREAD_ARCHIVED}{Endpoints.THREAD_PRIVATE}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {channel_id = channelId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
 
 			var threadReturn = JsonConvert.DeserializeObject<DiscordThreadResult>(res.Response);
@@ -4084,16 +4084,16 @@ namespace DisCatSharp.Net
 		/// <param name="limit">Limit the results.</param>
 		internal async Task<DiscordThreadResult> GetPublicArchivedThreadsAsync(ulong channelId, ulong? before, int? limit)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (before != null)
-				urlparams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
 			if (limit != null && limit > 0)
-				urlparams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}{Endpoints.THREAD_ARCHIVED}{Endpoints.THREAD_PUBLIC}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {channel_id = channelId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
 
 			var threadReturn = JsonConvert.DeserializeObject<DiscordThreadResult>(res.Response);
@@ -4109,16 +4109,16 @@ namespace DisCatSharp.Net
 		/// <param name="limit">Limit the results.</param>
 		internal async Task<DiscordThreadResult> GetPrivateArchivedThreadsAsync(ulong channelId, ulong? before, int? limit)
 		{
-			var urlparams = new Dictionary<string, string>();
+			var urlParams = new Dictionary<string, string>();
 			if (before != null)
-				urlparams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["before"] = before.Value.ToString(CultureInfo.InvariantCulture);
 			if (limit != null && limit > 0)
-				urlparams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
+				urlParams["limit"] = limit.Value.ToString(CultureInfo.InvariantCulture);
 
 			var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}{Endpoints.THREAD_ARCHIVED}{Endpoints.THREAD_PRIVATE}";
 			var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {channel_id = channelId }, out var path);
 
-			var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "", this.Discord.Configuration);
+			var url = Utilities.GetApiUriFor(path, urlParams.Any() ? BuildQueryString(urlParams) : "", this.Discord.Configuration);
 			var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
 
 			var threadReturn = JsonConvert.DeserializeObject<DiscordThreadResult>(res.Response);

--- a/DisCatSharp/Net/Rest/Endpoints.cs
+++ b/DisCatSharp/Net/Rest/Endpoints.cs
@@ -94,7 +94,7 @@ namespace DisCatSharp.Net
 		public const string INTEGRATIONS = "/integrations";
 
 		/// <summary>
-		/// The sinc endpoint.
+		/// The sync endpoint.
 		/// </summary>
 		public const string SYNC = "/sync";
 

--- a/DisCatSharp/Net/Rest/RateLimitBucket.cs
+++ b/DisCatSharp/Net/Rest/RateLimitBucket.cs
@@ -131,7 +131,7 @@ namespace DisCatSharp.Net
 		internal volatile bool IsUnlimited;
 
 		/// <summary>
-		/// If the initial request for this bucket that is deterternining the rate limits is currently executing
+		/// If the initial request for this bucket that is determining the rate limits is currently executing
 		/// This is a int because booleans can't be accessed atomically
 		/// 0 => False, all other values => True
 		/// </summary>

--- a/DisCatSharp/Net/Rest/RestClient.cs
+++ b/DisCatSharp/Net/Rest/RestClient.cs
@@ -162,7 +162,7 @@ namespace DisCatSharp.Net
 		/// </summary>
 		/// <param name="method">The method.</param>
 		/// <param name="route">The route.</param>
-		/// <param name="routeParams">The route paramaters.</param>
+		/// <param name="routeParams">The route parameters.</param>
 		/// <param name="url">The url.</param>
 		/// <returns>A ratelimit bucket.</returns>
 		public RateLimitBucket GetBucket(RestRequestMethod method, string route, object routeParams, out string url)
@@ -291,7 +291,7 @@ namespace DisCatSharp.Net
 						if (delay < TimeSpan.Zero)
 							delay = TimeSpan.FromMilliseconds(100);
 
-						this._logger.LogWarning(LoggerEvents.RatelimitPreemptive, "Pre-emptive ratelimit triggered - waiting until {0:yyyy-MM-dd HH:mm:ss zzz} ({1:c}).", resetDate, delay);
+						this._logger.LogWarning(LoggerEvents.RatelimitPreemptive, "Preemptive ratelimit triggered - waiting until {0:yyyy-MM-dd HH:mm:ss zzz} ({1:c}).", resetDate, delay);
 						Task.Delay(delay)
 							.ContinueWith(_ => this.ExecuteRequestAsync(request, null, null))
 							.LogTaskFault(this._logger, LogLevel.Error, LoggerEvents.RestError, "Error while executing request");
@@ -390,7 +390,7 @@ namespace DisCatSharp.Net
 										ApiEndpoint = request.Url.AbsoluteUri
 									});
 								}
-								this._logger.LogError(LoggerEvents.RatelimitHit, "Ratelimit hit, requeueing request to {0}", request.Url);
+								this._logger.LogError(LoggerEvents.RatelimitHit, "Ratelimit hit, requeuing request to {0}", request.Url);
 								await wait.ConfigureAwait(false);
 								this.ExecuteRequestAsync(request, bucket, ratelimitTcs)
 									.LogTaskFault(this._logger, LogLevel.Error, LoggerEvents.RestError, "Error while retrying request");
@@ -489,7 +489,7 @@ namespace DisCatSharp.Net
 				{
 					if (Interlocked.CompareExchange(ref bucket.LimitTesting, 1, 0) == 0)
 					{
-						// if we got here when the first request was just finishing, we must not create the waiter task as it would signel ExecureRequestAsync to bypass rate limiting
+						// if we got here when the first request was just finishing, we must not create the waiter task as it would signal ExecureRequestAsync to bypass rate limiting
 						if (bucket.LimitValid)
 							return null;
 

--- a/DisCatSharp/Net/Rest/RestClient.cs
+++ b/DisCatSharp/Net/Rest/RestClient.cs
@@ -615,7 +615,7 @@ namespace DisCatSharp.Net
 			}
 
 			// check if global b1nzy
-			if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.ToLowerInvariant() == "true")
+			if (hs.TryGetValue("X-RateLimit-Global", out var isGlobal) && isGlobal.ToLowerInvariant() == "true")
 			{
 				// global
 				global = true;
@@ -647,7 +647,7 @@ namespace DisCatSharp.Net
 			}
 
 
-			if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.ToLowerInvariant() == "true")
+			if (hs.TryGetValue("X-RateLimit-Global", out var isGlobal) && isGlobal.ToLowerInvariant() == "true")
 			{
 				if (response.ResponseCode != 429)
 				{
@@ -658,8 +658,8 @@ namespace DisCatSharp.Net
 				return;
 			}
 
-			var r1 = hs.TryGetValue("X-RateLimit-Limit", out var usesmax);
-			var r2 = hs.TryGetValue("X-RateLimit-Remaining", out var usesleft);
+			var r1 = hs.TryGetValue("X-RateLimit-Limit", out var usesMax);
+			var r2 = hs.TryGetValue("X-RateLimit-Remaining", out var usesLeft);
 			var r3 = hs.TryGetValue("X-RateLimit-Reset", out var reset);
 			var r4 = hs.TryGetValue("X-Ratelimit-Reset-After", out var resetAfter);
 			var r5 = hs.TryGetValue("X-Ratelimit-Bucket", out var hash);
@@ -673,36 +673,36 @@ namespace DisCatSharp.Net
 				return;
 			}
 
-			var clienttime = DateTimeOffset.UtcNow;
-			var resettime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(double.Parse(reset, CultureInfo.InvariantCulture));
-			var servertime = clienttime;
+			var clientTime = DateTimeOffset.UtcNow;
+			var resetTime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(double.Parse(reset, CultureInfo.InvariantCulture));
+			var serverTime = clientTime;
 			if (hs.TryGetValue("Date", out var rawDate))
-				servertime = DateTimeOffset.Parse(rawDate, CultureInfo.InvariantCulture).ToUniversalTime();
+				serverTime = DateTimeOffset.Parse(rawDate, CultureInfo.InvariantCulture).ToUniversalTime();
 
-			var resetdelta = resettime - servertime;
-			//var difference = clienttime - servertime;
+			var resetDelta = resetTime - serverTime;
+			//var difference = clientTime - serverTime;
 			//if (Math.Abs(difference.TotalSeconds) >= 1)
 			////    this.Logger.LogMessage(LogLevel.DebugBaseDiscordClient.RestEventId,  $"Difference between machine and server time: {difference.TotalMilliseconds.ToString("#,##0.00", CultureInfo.InvariantCulture)}ms", DateTime.Now);
 			//else
 			//    difference = TimeSpan.Zero;
 
 			if (request.RateLimitWaitOverride.HasValue)
-				resetdelta = TimeSpan.FromSeconds(request.RateLimitWaitOverride.Value);
-			var newReset = clienttime + resetdelta;
+				resetDelta = TimeSpan.FromSeconds(request.RateLimitWaitOverride.Value);
+			var newReset = clientTime + resetDelta;
 
 			if (this._useResetAfter)
 			{
 				bucket.ResetAfter = TimeSpan.FromSeconds(double.Parse(resetAfter, CultureInfo.InvariantCulture));
-				newReset = clienttime + bucket.ResetAfter.Value + (request.RateLimitWaitOverride.HasValue
-					? resetdelta
+				newReset = clientTime + bucket.ResetAfter.Value + (request.RateLimitWaitOverride.HasValue
+					? resetDelta
 					: TimeSpan.Zero);
 				bucket.ResetAfterOffset = newReset;
 			}
 			else
 				bucket.Reset = newReset;
 
-			var maximum = int.Parse(usesmax, CultureInfo.InvariantCulture);
-			var remaining = int.Parse(usesleft, CultureInfo.InvariantCulture);
+			var maximum = int.Parse(usesMax, CultureInfo.InvariantCulture);
+			var remaining = int.Parse(usesLeft, CultureInfo.InvariantCulture);
 
 			if (ratelimitTcs != null)
 			{

--- a/DisCatSharp/Net/WebSocket/WebSocketClient.cs
+++ b/DisCatSharp/Net/WebSocket/WebSocketClient.cs
@@ -404,7 +404,7 @@ namespace DisCatSharp.Net.WebSocket
 		/// Events the error handler.
 		/// </summary>
 		/// <param name="asyncEvent">The event.</param>
-		/// <param name="ex">The exeption.</param>
+		/// <param name="ex">The exception.</param>
 		/// <param name="handler">The handler.</param>
 		/// <param name="sender">The sender.</param>
 		/// <param name="eventArgs">The event args.</param>


### PR DESCRIPTION
# Description

I think the documentation can be improved upon in many regards. It's often kind of unhelpful and not really descriptive, as well as internally inconsistent. While this PR can't possibly seek to fix everything about it, I feel like fixing most of the more glaring spelling errors is a step in the right direction.

The two breaking changes are:
1. Numerous parameter name changes in public facing methods, which are only breaking if the methods are called with named arguments (so should probably be negligible).
2. `DiscordShortlink` being turned into a static readonly class. The class seems fairly obscure, so I assume the effect will likely be arguably negligible.

Breaking changes are in a separate commit so can be cherry-picked out if needed.

One of the spelling errors was actually in the Json attribute of a payload type, which likely resulted in a bug when that parameter was used, making this a bug fix as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

ReSharper ReSpeller

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
