### PR TITLE
Proper exception log when registering app commands fails

### DIFF
--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
@@ -554,9 +554,16 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 			catch (Exception ex)
 			{
 				if (ex is BadRequestException brex)
-					this.Client.Logger.LogCritical(brex, $"There was an error registering application commands: {brex.JsonMessage}");
+				{
+					this.Client.Logger.LogCritical(brex, $"There was an error registering application commands: {brex.WebResponse.Response}");
+				}
 				else
-					this.Client.Logger.LogCritical(ex, $"There was an error parsing the application commands");
+				{
+					if (ex.InnerException is BadRequestException brex1)
+						this.Client.Logger.LogCritical(brex1, $"There was an error registering application commands: {brex1.WebResponse.Response}");
+					else
+						this.Client.Logger.LogCritical(ex, $"There was an error parsing the application commands");
+				}
 				s_errored = true;
 			}
 		}
@@ -681,9 +688,16 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 			catch (Exception ex)
 			{
 				if (ex is BadRequestException brex)
-					this.Client.Logger.LogCritical(brex, $"There was an error registering application commands: {brex.JsonMessage}");
+				{
+					this.Client.Logger.LogCritical(brex, $"There was an error registering application commands: {brex.WebResponse.Response}");
+				}
 				else
-					this.Client.Logger.LogCritical(ex, $"There was an general error registering application commands");
+				{
+					if (ex.InnerException is BadRequestException brex1)
+						this.Client.Logger.LogCritical(brex1, $"There was an error registering application commands: {brex1.WebResponse.Response}");
+					else
+						this.Client.Logger.LogCritical(ex, $"There was an general error registering application commands");
+				}
 				s_errored = true;
 			}
 		}

--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
@@ -559,7 +559,7 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 				}
 				else
 				{
-					if (ex.InnerException is BadRequestException brex1)
+					if (ex.InnerException is not null && ex.InnerException is BadRequestException brex1)
 						this.Client.Logger.LogCritical(brex1, $"There was an error registering application commands: {brex1.WebResponse.Response}");
 					else
 						this.Client.Logger.LogCritical(ex, $"There was an error parsing the application commands");
@@ -693,7 +693,7 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 				}
 				else
 				{
-					if (ex.InnerException is BadRequestException brex1)
+					if (ex.InnerException is not null && ex.InnerException is BadRequestException brex1)
 						this.Client.Logger.LogCritical(brex1, $"There was an error registering application commands: {brex1.WebResponse.Response}");
 					else
 						this.Client.Logger.LogCritical(ex, $"There was an general error registering application commands");


### PR DESCRIPTION
Previously those 2 `if (ex is BadRequestException brex)` weren't actually true as the Exception thrown are ArragateExcpetions. 

This should now properly inform the user what the problem actually is. The change from `JsonMessage` to `WebResponse.Response` is because the JsonMessage will always be "Invalid Form Body" and not actually show you what the error is. We could maybe format that a bit better in the future but for now, this should improve the current situation of having no information at all to go off of.