### PR TITLE
Fix ChannelFlagsChange Cast & NullReference

### DIFF
--- a/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
+++ b/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
@@ -326,8 +326,8 @@ public partial class DiscordGuild
 							case "flags":
 								entrychn.ChannelFlagsChange = new PropertyChange<ChannelFlags>()
 								{
-									Before = (ChannelFlags)(int)xc.OldValue,
-									After = (ChannelFlags)(int)xc.NewValue
+									Before = (ChannelFlags)(long)xc.OldValue,
+									After = (ChannelFlags)(long)xc.NewValue
 								};
 								break;
 

--- a/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
+++ b/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
@@ -326,8 +326,8 @@ public partial class DiscordGuild
 							case "flags":
 								entrychn.ChannelFlagsChange = new PropertyChange<ChannelFlags>()
 								{
-									Before = (ChannelFlags)(long)xc.OldValue,
-									After = (ChannelFlags)(long)xc.NewValue
+									Before = (ChannelFlags)(long)(xc.OldValue ?? 0L),
+									After = (ChannelFlags)(long)(xc.NewValue ?? 0L)
 								};
 								break;
 

--- a/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
+++ b/DisCatSharp/Entities/Guild/DiscordGuild.AuditLog.cs
@@ -1274,6 +1274,10 @@ public partial class DiscordGuild
 					}
 					break;
 
+				// TODO: Handle ApplicationCommandPermissionUpdate
+				case AuditLogActionType.ApplicationCommandPermissionUpdate:
+					break;
+
 				default:
 					this.Discord.Logger.LogWarning(LoggerEvents.AuditLog, "Unknown audit log action type: {0} - this should be reported to library developers", (int)xac.ActionType);
 					break;

--- a/DisCatSharp/Enums/Guild/AuditLogActionType.cs
+++ b/DisCatSharp/Enums/Guild/AuditLogActionType.cs
@@ -267,13 +267,28 @@ public enum AuditLogActionType
 	/// </summary>
 	ThreadDelete = 112,
 
+	/// <summary>
+	/// Indicates that the permissions for an application command was updated.
+	/// </summary>
 	ApplicationCommandPermissionUpdate = 121,
 
+	/// <summary>
+	/// Indicates that a new automod rule has been added.
+	/// </summary>
 	AutoModerationRuleCreate = 140,
 
+	/// <summary>
+	/// Indicates that a automod rule has been updated.
+	/// </summary>
 	AutoModerationRuleUpdate = 141,
 
+	/// <summary>
+	/// Indicates that a automod rule has been deleted.
+	/// </summary>
 	AutoModerationRuleDelete = 142,
 
+	/// <summary>
+	/// Indicates that automod blocked a message.
+	/// </summary>
 	AutoModerationBlockMessage = 143
 }


### PR DESCRIPTION
Fix 2 issues my bot has been reporting for a few days.

In addition, i added some missing documentation in [AuditLogActionType.cs](https://github.com/Aiko-IT-Systems/DisCatSharp/compare/fix-cast-auditlog?expand=1#diff-60396f7551ed6df25f3cde8ed49f44790558f25e17679fa0ee4e9c26eefa9bae). 

I also added placeholder handling for `AuditLogActionType.ApplicationCommandPermissionUpdate`, this needs to be handled in a future update but this goes beyond my expertise (~~and my willingness to familiarize myself with our audit log system without help lol~~).

As usually, i tested these changes with my bot.

```cs
System.AggregateException: One or more errors occurred. (Unable to cast object of type 'System.Int64' to type 'System.Int32'.)
 ---> System.InvalidCastException: Unable to cast object of type 'System.Int64' to type 'System.Int32'.
   at DisCatSharp.Entities.DiscordGuild.GetAuditLogsAsync(Nullable`1 limit, DiscordMember byMember, Nullable`1 actionType)
   at Project_Ichigo.Events.ActionlogEvents.<>c__DisplayClass20_0.<<ChannelDeleted>b__0>d.MoveNext() in /home/github-actions/Project-Ichigo/Project-Ichigo/Events/ActionlogEvents.cs:line 1031
   --- End of inner exception stack trace ---
```

```cs
System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at DisCatSharp.Entities.DiscordGuild.GetAuditLogsAsync(Nullable`1 limit, DiscordMember byMember, Nullable`1 actionType)
   at Project_Ichigo.Events.ActionlogEvents.<>c__DisplayClass19_0.<<ChannelCreated>b__0>d.MoveNext() in /home/github-actions/Project-Ichigo/Project-Ichigo/Events/ActionlogEvents.cs:line 987
   --- End of inner exception stack trace ---
```