### PR TITLE
Fix tags initialization

### DIFF
--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -27,6 +27,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DisCatSharp.Common;
@@ -683,12 +684,7 @@ public sealed partial class DiscordClient
 			foreach (var xc in guild.Channels.Values)
 			{
 				xc.GuildId = guild.Id;
-				xc.Discord = this;
-				foreach (var xo in xc.PermissionOverwritesInternal)
-				{
-					xo.Discord = this;
-					xo.ChannelId = xc.Id;
-				}
+				xc.Initialize(this);
 			}
 
 			guild.RolesInternal ??= new ConcurrentDictionary<ulong, DiscordRole>();
@@ -781,17 +777,7 @@ public sealed partial class DiscordClient
 	/// <param name="channel">The channel.</param>
 	internal async Task OnChannelCreateEventAsync(DiscordChannel channel)
 	{
-		channel.Discord = this;
-		foreach (var xo in channel.PermissionOverwritesInternal)
-		{
-			xo.Discord = this;
-			xo.ChannelId = channel.Id;
-		}
-		foreach (var xo in channel.InternalAvailableTags)
-		{
-			xo.Discord = this;
-			xo.ChannelId = channel.Id;
-		}
+		channel.Initialize(this);
 
 		this.GuildsInternal[channel.GuildId.Value].ChannelsInternal[channel.Id] = channel;
 
@@ -890,11 +876,7 @@ public sealed partial class DiscordClient
 
 			channelNew.PermissionOverwritesInternal.Clear();
 
-			foreach (var po in channel.PermissionOverwritesInternal)
-			{
-				po.Discord = this;
-				po.ChannelId = channel.Id;
-			}
+			channel.Initialize(this);
 
 			channelNew.PermissionOverwritesInternal.AddRange(channel.PermissionOverwritesInternal);
 
@@ -960,12 +942,7 @@ public sealed partial class DiscordClient
 		guild.ChannelsInternal.Clear();
 		foreach (var channel in channels.ToList())
 		{
-			channel.Discord = this;
-			foreach (var xo in channel.PermissionOverwritesInternal)
-			{
-				xo.Discord = this;
-				xo.ChannelId = channel.Id;
-			}
+			channel.Initialize(this);
 			guild.ChannelsInternal[channel.Id] = channel;
 		}
 	}
@@ -1061,12 +1038,7 @@ public sealed partial class DiscordClient
 		foreach (var xc in guild.ChannelsInternal.Values)
 		{
 			xc.GuildId = guild.Id;
-			xc.Discord = this;
-			foreach (var xo in xc.PermissionOverwritesInternal)
-			{
-				xo.Discord = this;
-				xo.ChannelId = xc.Id;
-			}
+			xc.Initialize(this);
 		}
 		foreach (var xt in guild.ThreadsInternal.Values)
 		{
@@ -1210,12 +1182,7 @@ public sealed partial class DiscordClient
 		foreach (var xc in guild.ChannelsInternal.Values)
 		{
 			xc.GuildId = guild.Id;
-			xc.Discord = this;
-			foreach (var xo in xc.PermissionOverwritesInternal)
-			{
-				xo.Discord = this;
-				xo.ChannelId = xc.Id;
-			}
+			xc.Initialize(this);
 		}
 		foreach (var xc in guild.ThreadsInternal.Values)
 		{

--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -862,13 +862,8 @@ public sealed partial class DiscordClient
 				if (channelNew.InternalAvailableTags != null && channelNew.InternalAvailableTags.Any())
 					channelNew.InternalAvailableTags.Clear();
 
-				foreach (var fpt in channel.InternalAvailableTags)
-				{
-					fpt.Discord = this;
-					fpt.ChannelId = channel.Id;
-				}
-
-				channelNew.InternalAvailableTags.AddRange(channel.InternalAvailableTags);
+				if (channel.InternalAvailableTags != null && channel.InternalAvailableTags.Any())
+					channelNew.InternalAvailableTags.AddRange(channel.InternalAvailableTags);
 			}
 			else
 			{

--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -827,6 +827,27 @@ public sealed partial class DiscordClient
 				QualityMode = channelNew.QualityMode,
 				DefaultAutoArchiveDuration = channelNew.DefaultAutoArchiveDuration,
 			};
+
+			channelNew.Bitrate = channel.Bitrate;
+			channelNew.Name = channel.Name;
+			channelNew.Position = channel.Position;
+			channelNew.Topic = channel.Topic;
+			channelNew.UserLimit = channel.UserLimit;
+			channelNew.ParentId = channel.ParentId;
+			channelNew.IsNsfw = channel.IsNsfw;
+			channelNew.PerUserRateLimit = channel.PerUserRateLimit;
+			channelNew.Type = channel.Type;
+			channelNew.RtcRegionId = channel.RtcRegionId;
+			channelNew.QualityMode = channel.QualityMode;
+			channelNew.DefaultAutoArchiveDuration = channel.DefaultAutoArchiveDuration;
+
+			channelNew.PermissionOverwritesInternal.Clear();
+
+			channel.Initialize(this);
+
+			channelNew.PermissionOverwritesInternal.AddRange(channel.PermissionOverwritesInternal);
+
+
 			if (channel.Type == ChannelType.Forum)
 			{
 				channelOld.PostCreateUserRateLimit = channelNew.PostCreateUserRateLimit;
@@ -848,7 +869,8 @@ public sealed partial class DiscordClient
 				}
 
 				channelNew.InternalAvailableTags.AddRange(channel.InternalAvailableTags);
-			} else
+			}
+			else
 			{
 				channelOld.PostCreateUserRateLimit = null;
 				channelOld.InternalAvailableTags = null;
@@ -860,25 +882,8 @@ public sealed partial class DiscordClient
 				channelNew.DefaultReactionEmoji = null;
 				channelNew.InternalAvailableTags = null;
 			}
-
-			channelNew.Bitrate = channel.Bitrate;
-			channelNew.Name = channel.Name;
-			channelNew.Position = channel.Position;
-			channelNew.Topic = channel.Topic;
-			channelNew.UserLimit = channel.UserLimit;
-			channelNew.ParentId = channel.ParentId;
-			channelNew.IsNsfw = channel.IsNsfw;
-			channelNew.PerUserRateLimit = channel.PerUserRateLimit;
-			channelNew.Type = channel.Type;
-			channelNew.RtcRegionId = channel.RtcRegionId;
-			channelNew.QualityMode = channel.QualityMode;
-			channelNew.DefaultAutoArchiveDuration = channel.DefaultAutoArchiveDuration;
-
-			channelNew.PermissionOverwritesInternal.Clear();
-
-			channel.Initialize(this);
-
-			channelNew.PermissionOverwritesInternal.AddRange(channel.PermissionOverwritesInternal);
+			channelOld.Initialize(this);
+			channelNew.Initialize(this);
 
 			if (this.Configuration.AutoRefreshChannelCache && gld != null)
 			{

--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -27,7 +27,6 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using DisCatSharp.Common;

--- a/DisCatSharp/Clients/DiscordClient.cs
+++ b/DisCatSharp/Clients/DiscordClient.cs
@@ -1148,11 +1148,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
 			{
 				if (guild.ChannelsInternal.TryGetValue(channel.Id, out _)) continue;
 
-				foreach (var overwrite in channel.PermissionOverwritesInternal)
-				{
-					overwrite.Discord = this;
-					overwrite.ChannelId = channel.Id;
-				}
+				channel.Initialize(this);
 
 				guild.ChannelsInternal[channel.Id] = channel;
 			}

--- a/DisCatSharp/Entities/Channel/DiscordChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordChannel.cs
@@ -218,7 +218,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 	/// List of available tags for forum posts.
 	/// </summary>
 	[JsonProperty("available_tags", NullValueHandling = NullValueHandling.Ignore)]
-	internal List<ForumPostTag> InternalAvailableTags { get; set; }
+	internal List<ForumPostTag> InternalAvailableTags { get; set; } = new();
 
 	/// <summary>
 	/// List of available tags for forum posts.
@@ -414,6 +414,8 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 		foreach (var ovr in this.PermissionOverwritesInternal)
 			ovrs.Add(await new DiscordOverwriteBuilder().FromAsync(ovr).ConfigureAwait(false));
 
+		// TODO: Add forum tags option missing?
+
 		var bitrate = this.Bitrate;
 		var userLimit = this.UserLimit;
 		Optional<int?> perUserRateLimit = this.PerUserRateLimit;
@@ -606,6 +608,21 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 		return this.Guild.Channels.Values.ToList().AsReadOnly();
 	}
 
+	internal void Initialize(BaseDiscordClient client)
+	{
+		this.Discord = client;
+		foreach (var xo in this.PermissionOverwritesInternal)
+		{
+			xo.Discord = this.Discord;
+			xo.ChannelId = this.Id;
+		}
+		foreach (var xo in this.InternalAvailableTags)
+		{
+			xo.Discord = this.Discord;
+			xo.ChannelId = this.Id;
+		}
+	}
+
 	/// <summary>
 	/// Refreshes the positions.
 	/// </summary>
@@ -615,12 +632,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 		this.Guild.ChannelsInternal.Clear();
 		foreach (var channel in channels.ToList())
 		{
-			channel.Discord = this.Discord;
-			foreach (var xo in channel.PermissionOverwritesInternal)
-			{
-				xo.Discord = this.Discord;
-				xo.ChannelId = channel.Id;
-			}
+			channel.Initialize(this.Discord);
 			this.Guild.ChannelsInternal[channel.Id] = channel;
 		}
 	}

--- a/DisCatSharp/Entities/Channel/DiscordChannel.cs
+++ b/DisCatSharp/Entities/Channel/DiscordChannel.cs
@@ -616,10 +616,13 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 			xo.Discord = this.Discord;
 			xo.ChannelId = this.Id;
 		}
-		foreach (var xo in this.InternalAvailableTags)
+		if (this.InternalAvailableTags != null)
 		{
-			xo.Discord = this.Discord;
-			xo.ChannelId = this.Id;
+			foreach (var xo in this.InternalAvailableTags)
+			{
+				xo.Discord = this.Discord;
+				xo.ChannelId = this.Id;
+			}
 		}
 	}
 

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -1636,12 +1636,7 @@ public sealed class DiscordApiClient
 		var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
 		var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
-		ret.Discord = this.Discord;
-		foreach (var xo in ret.PermissionOverwritesInternal)
-		{
-			xo.Discord = this.Discord;
-			xo.ChannelId = ret.Id;
-		}
+		ret.Initialize(this.Discord);
 
 		return ret;
 	}
@@ -1700,12 +1695,7 @@ public sealed class DiscordApiClient
 		var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
 		var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
-		ret.Discord = this.Discord;
-		foreach (var xo in ret.PermissionOverwritesInternal)
-		{
-			xo.Discord = this.Discord;
-			xo.ChannelId = ret.Id;
-		}
+		ret.Initialize(this.Discord);
 
 		return ret;
 	}
@@ -1913,17 +1903,7 @@ public sealed class DiscordApiClient
 		var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
 		var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
-		ret.Discord = this.Discord;
-		foreach (var xo in ret.PermissionOverwritesInternal)
-		{
-			xo.Discord = this.Discord;
-			xo.ChannelId = ret.Id;
-		}
-		foreach(var xo in ret.InternalAvailableTags)
-		{
-			xo.Discord = this.Discord;
-			xo.ChannelId = ret.Id;
-		}
+		ret.Initialize(this.Discord);
 
 		return ret;
 	}
@@ -2120,11 +2100,7 @@ public sealed class DiscordApiClient
 		var channelsRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
 
 		foreach (var ret in channelsRaw)
-			foreach (var xo in ret.PermissionOverwritesInternal)
-			{
-				xo.Discord = this.Discord;
-				xo.ChannelId = ret.Id;
-			}
+			ret.Initialize(this.Discord);
 
 		return new ReadOnlyCollection<DiscordChannel>(new List<DiscordChannel>(channelsRaw));
 	}


### PR DESCRIPTION
Two issues:
- `DiscordClient.GetChannelAsync` caused `NullReferenceException` when there were no tags
- Tags were not being initialized consistently