### PR TITLE
Fetch widget

### DIFF
--- a/DisCatSharp/Clients/DiscordClient.cs
+++ b/DisCatSharp/Clients/DiscordClient.cs
@@ -715,6 +715,35 @@ public sealed partial class DiscordClient : BaseDiscordClient
 	}
 
 	/// <summary>
+	/// Gets a guild widget.
+	/// </summary>
+	/// <param name="id">The Guild Id.</param>
+	/// <returns>A guild widget.</returns>
+	/// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+	/// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+	public Task<DiscordWidget> GetGuildWidgetAsync(ulong id)
+		=> this.ApiClient.GetGuildWidgetAsync(id);
+
+	/// <summary>
+	/// Tries to get a guild widget.
+	/// </summary>
+	/// <param name="id">The Guild Id.</param>
+	/// <returns>The requested guild widget or null if not found.</returns>
+	/// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+	/// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+	public async Task<DiscordWidget?> TryGetGuildWidgetAsync(ulong id)
+	{
+		try
+		{
+			return await this.ApiClient.GetGuildWidgetAsync(id);
+		}
+		catch (NotFoundException)
+		{
+			return null;
+		}
+	}
+
+	/// <summary>
 	/// Gets an invite.
 	/// </summary>
 	/// <param name="code">The invite code.</param>

--- a/DisCatSharp/Net/Rest/DiscordApiClient.cs
+++ b/DisCatSharp/Net/Rest/DiscordApiClient.cs
@@ -965,7 +965,7 @@ public sealed class DiscordApiClient
 
 		var ret = json.ToDiscordObject<DiscordWidget>();
 		ret.Discord = this.Discord;
-		ret.Guild = this.Discord.Guilds[guildId];
+		ret.Guild = (this.Discord.Guilds.ContainsKey(guildId)) ? this.Discord.Guilds[guildId] : null;
 
 		ret.Channels = ret.Guild == null
 			? rawChannels.Select(r => new DiscordChannel


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adds `DiscordClient.GetGuildWidgetAsync(ulong)`, `.TryGetGuildWidgetAsync(ulong)`
Hacktober Task 8: https://discord.com/channels/858089281214087179/1025281336975556659

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fetched the Guild Widget via `DiscordClient.GetGuildWidgetAsync(id)`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

@Aiko-IT-Systems/discatsharp
