### PR TITLE
fix: DiscordEmoji operator == add compare name

### DIFF
--- a/DisCatSharp/Entities/Emoji/DiscordEmoji.cs
+++ b/DisCatSharp/Entities/Emoji/DiscordEmoji.cs
@@ -165,7 +165,7 @@ public partial class DiscordEmoji : SnowflakeObject, IEquatable<DiscordEmoji>
 		var o1 = e1 as object;
 		var o2 = e2 as object;
 
-		return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || e1.Id == e2.Id);
+		return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || (e1.Id == e2.Id && e1.Name == e2.Name));
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes (DiscordEmoji Equals issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

First of all, I'm not good at English.

i try to use SendPaginatedMessageAsync with PaginationEmojis.

when i react emoji, message was modified but message content wasn't changed.

because DiscordEmoji operator == is just compare emoji id and PaginationEmojis Id is all 0 so PaginateAsync is always return SkipLeft.

**Test Configuration**:
* OS: Windows11 22H2 22621.1413

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

@Aiko-IT-Systems/discatsharp
