### PR TITLE
docs: uniform appCommands example code

### DIFF
--- a/DisCatSharp.Docs/articles/modules/application_commands/events.md
+++ b/DisCatSharp.Docs/articles/modules/application_commands/events.md
@@ -16,17 +16,17 @@ Suppose we have a certain class with commands that must be executed ONLY in the 
 public class MyGuildCommands : ApplicationCommandsModule
 {
     [SlashCommand("mute", "Mute user.")]
-    public static async Task Mute(InteractionContext context)
+    public static async Task Mute(InteractionContext ctx)
     {
 
     }
     [SlashCommand("kick", "Kick user.")]
-    public static async Task Kick(InteractionContext context)
+    public static async Task Kick(InteractionContext ctx)
     {
 
     }
     [SlashCommand("ban", "Ban user.")]
-    public static async Task Ban(InteractionContext context)
+    public static async Task Ban(InteractionContext ctx)
     {
 
     }
@@ -45,17 +45,17 @@ public class MyGuildCommands : ApplicationCommandsModule
     }
 
     [SlashCommand("mute", "Mute user.")]
-    public static async Task Mute(InteractionContext context)
+    public static async Task Mute(InteractionContext ctx)
     {
 
     }
     [SlashCommand("kick", "Kick user.")]
-    public static async Task Kick(InteractionContext context)
+    public static async Task Kick(InteractionContext ctx)
     {
 
     }
     [SlashCommand("ban", "Ban user.")]
-    public static async Task Ban(InteractionContext context)
+    public static async Task Ban(InteractionContext ctx)
     {
 
     }

--- a/DisCatSharp.Docs/articles/modules/application_commands/intro.md
+++ b/DisCatSharp.Docs/articles/modules/application_commands/intro.md
@@ -30,7 +30,7 @@ Simple slash command:
 public class MyCommand : ApplicationCommandsModule
 {
     [SlashCommand("my_command", "This is description of the command.")]
-    public async Task MySlashCommand(InteractionContext context)
+    public async Task MySlashCommand(InteractionContext ctx)
     {
 
     }
@@ -42,7 +42,7 @@ Simple context menu command:
 public class MySecondCommand : ApplicationCommandsModule
 {
     [ContextMenu(ApplicationCommandType.User, "My Command")]
-    public async Task MyContextMenuCommand(ContextMenuContext context)
+    public async Task MyContextMenuCommand(ContextMenuContext ctx)
     {
 
     }
@@ -51,7 +51,7 @@ public class MySecondCommand : ApplicationCommandsModule
 
 Now let's add some actions to the commands, for example, send a reply:
 ```cs
-await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
 {
     Content = "Hello :3"
 });
@@ -59,7 +59,7 @@ await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSour
 
 If the command will be executed for more than 3 seconds, we must response at the beginning of execution and edit it at the end.
 ```cs
-await context.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder());
+await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource, new DiscordInteractionResponseBuilder());
 
 await Task.Delay(5000); // Simulating a long command execution.
 
@@ -110,17 +110,17 @@ public class MyCommand : ApplicationCommandsModule
     public class MyCommandGroup : ApplicationCommandsModule
     {
         [SlashCommand("first", "This is description of the command.")]
-        public async Task MySlashCommand(InteractionContext context)
+        public async Task MySlashCommand(InteractionContext ctx)
         {
-            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
             {
                 Content = "This is first subcommand."
             });
         }
         [SlashCommand("second", "This is description of the command.")]
-        public async Task MySecondCommand(InteractionContext context)
+        public async Task MySecondCommand(InteractionContext ctx)
         {
-            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
             {
                 Content = "This is second subcommand."
             });

--- a/DisCatSharp.Docs/articles/modules/application_commands/options.md
+++ b/DisCatSharp.Docs/articles/modules/application_commands/options.md
@@ -31,9 +31,9 @@ They should be after [InteractionContext](xref:DisCatSharp.ApplicationCommands.C
 public class MyCommand : ApplicationCommandsModule
 {
     [SlashCommand("my_command", "This is description of the command.")]
-    public static async Task MySlashCommand(InteractionContext context, [Option("argument", "This is description of the option.")] string firstParam)
+    public static async Task MySlashCommand(InteractionContext ctx, [Option("argument", "This is description of the option.")] string firstParam)
     {
-        await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+        await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
         {
             Content = firstParam
         });
@@ -58,7 +58,7 @@ This is the easiest option. We just need to specify the required Enum as a comma
 public class MyCommand : ApplicationCommandsModule
 {
     [SlashCommand("my_command", "This is description of the command.")]
-    public static async Task MySlashCommand(InteractionContext context, [Option("enum_param", "Description")] MyEnum enumParameter)
+    public static async Task MySlashCommand(InteractionContext ctx, [Option("enum_param", "Description")] MyEnum enumParameter)
     {
 
     }
@@ -89,7 +89,7 @@ With this way, you can get rid of unnecessary conversions within the command.
 To do this, you need to add one or more [Choice Attributes](xref:DisCatSharp.ApplicationCommands.Attributes.ChoiceAttribute) before the [Option](xref:DisCatSharp.ApplicationCommands.Attributes.OptionAttribute) attribute
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [Choice("First option", 1)] [Choice("Second option", 2)] [Option("option", "Description")] long firstParam)
+public static async Task MySlashCommand(InteractionContext ctx, [Choice("First option", 1)] [Choice("Second option", 2)] [Option("option", "Description")] long firstParam)
 {
 
 }
@@ -134,7 +134,7 @@ Now let's add our new provider to the command.
 
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [ChoiceProvider(typeof(MyChoiceProvider))] [Option("option", "Description")] long option)
+public static async Task MySlashCommand(InteractionContext ctx, [ChoiceProvider(typeof(MyChoiceProvider))] [Option("option", "Description")] long option)
 {
 
 }
@@ -145,7 +145,7 @@ All the code that we got:
 public class MyCommand : ApplicationCommandsModule
 {
     [SlashCommand("my_command", "This is description of the command.")]
-    public static async Task MySlashCommand(InteractionContext context, [ChoiceProvider(typeof(MyChoiceProvider))] [Option("option", "Description")] long option)
+    public static async Task MySlashCommand(InteractionContext ctx, [ChoiceProvider(typeof(MyChoiceProvider))] [Option("option", "Description")] long option)
     {
 
     }
@@ -196,7 +196,7 @@ The changes are that instead of [IChoiceProvider](xref:DisCatSharp.ApplicationCo
 Now we add it to the command:
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [Autocomplete(typeof(MyAutocompleteProvider))] [Option("option", "Description", true)] long option)
+public static async Task MySlashCommand(InteractionContext ctx, [Autocomplete(typeof(MyAutocompleteProvider))] [Option("option", "Description", true)] long option)
 {
 
 }
@@ -212,7 +212,7 @@ This can be done by adding the [ChannelTypes](xref:DisCatSharp.ApplicationComman
 
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [Option("channel", "You can select only text channels."), ChannelTypes(ChannelType.Text)] DiscordChannel channel)
+public static async Task MySlashCommand(InteractionContext ctx, [Option("channel", "You can select only text channels."), ChannelTypes(ChannelType.Text)] DiscordChannel channel)
 {
 
 }
@@ -229,7 +229,7 @@ It can be used only for the types `double`, `int` and `long` tho.
 
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [Option("number", "You can select only a certain range."), MinimumValue(50), MaximumValue(100)] int numbers)
+public static async Task MySlashCommand(InteractionContext ctx, [Option("number", "You can select only a certain range."), MinimumValue(50), MaximumValue(100)] int numbers)
 {
 
 }
@@ -244,7 +244,7 @@ It can be used only for the type `string`.
 
 ```cs
 [SlashCommand("my_command", "This is description of the command.")]
-public static async Task MySlashCommand(InteractionContext context, [Option("text", "You can only send text with a length between 10 and 50 characters."), MinimumLength(10), MaximumLength(50)] string text)
+public static async Task MySlashCommand(InteractionContext ctx, [Option("text", "You can only send text with a length between 10 and 50 characters."), MinimumLength(10), MaximumLength(50)] string text)
 {
 
 }

--- a/DisCatSharp.Docs/articles/modules/application_commands/translations/using.md
+++ b/DisCatSharp.Docs/articles/modules/application_commands/translations/using.md
@@ -51,17 +51,17 @@ public class MyCommand : ApplicationCommandsModule
     public class MyCommandGroup : ApplicationCommandsModule
     {
         [SlashCommand("first", "This is description of the command.")]
-        public async Task MySlashCommand(InteractionContext context)
+        public async Task MySlashCommand(InteractionContext ctx)
         {
-            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
             {
                 Content = "This is first subcommand."
             });
         }
         [SlashCommand("second", "This is description of the command.")]
-        public async Task MySecondCommand(InteractionContext context, [Option("value", "Some string value.")] string value)
+        public async Task MySecondCommand(InteractionContext ctx, [Option("value", "Some string value.")] string value)
         {
-            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder()
             {
                 Content = "This is second subcommand. The value was " + value
             });
@@ -138,13 +138,13 @@ Now imagine, that your class look like this example:
 public class MySimpleCommands : ApplicationCommandsModule
 {
     [SlashCommand("my_command", "This is description of the command.")]
-    public async Task MySlashCommand(InteractionContext context)
+    public async Task MySlashCommand(InteractionContext ctx)
     {
 
     }
 
     [ContextMenu(ApplicationCommandType.User, "My Command")]
-    public async Task MyContextMenuCommand(ContextMenuContext context)
+    public async Task MyContextMenuCommand(ContextMenuContext ctx)
     {
 
     }


### PR DESCRIPTION
# Description

Changes `context` to `ctx` in the Application Commands articles' example code to match the rest of the documentation.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

@Aiko-IT-Systems/discatsharp
