### PR TITLE
feat: additional properties for app command registered commands

### DIFF
--- a/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
+++ b/DisCatSharp.ApplicationCommands/ApplicationCommandsExtension.cs
@@ -57,22 +57,22 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 	/// <summary>
 	/// A list of methods for top level commands.
 	/// </summary>
-	private static List<CommandMethod> s_commandMethods { get; set; } = new();
+	internal static List<CommandMethod> s_commandMethods { get; set; } = new();
 
 	/// <summary>
 	/// List of groups.
 	/// </summary>
-	private static List<GroupCommand> s_groupCommands { get; set; } = new();
+	internal static List<GroupCommand> s_groupCommands { get; set; } = new();
 
 	/// <summary>
 	/// List of groups with subgroups.
 	/// </summary>
-	private static List<SubGroupCommand> s_subGroupCommands { get; set; } = new();
+	internal static List<SubGroupCommand> s_subGroupCommands { get; set; } = new();
 
 	/// <summary>
 	/// List of context menus.
 	/// </summary>
-	private static List<ContextMenuCommand> s_contextMenuCommands { get; set; } = new();
+	internal static List<ContextMenuCommand> s_contextMenuCommands { get; set; } = new();
 
 	/// <summary>
 	/// List of global commands on discords backend.
@@ -107,8 +107,10 @@ public sealed class ApplicationCommandsExtension : BaseExtension
 	/// <summary>
 	/// Gets a list of registered commands. The key is the guild id (null if global).
 	/// </summary>
-	public IReadOnlyList<KeyValuePair<ulong?, IReadOnlyList<DiscordApplicationCommand>>> RegisteredCommands
-		=> s_registeredCommands;
+	public IReadOnlyList<KeyValuePair<ulong?, IReadOnlyList<RegisteredDiscordApplicationCommand>>> RegisteredCommands
+		=> s_registeredCommands.Select(guild =>
+			new KeyValuePair<ulong?, IReadOnlyList<RegisteredDiscordApplicationCommand>>(guild.Key, guild.Value
+					.Select(parent => new RegisteredDiscordApplicationCommand(parent)).ToList())).ToList();
 	private static List<KeyValuePair<ulong?, IReadOnlyList<DiscordApplicationCommand>>> s_registeredCommands = new();
 
 	/// <summary>

--- a/DisCatSharp.ApplicationCommands/Entities/RegisteredDiscordApplicationCommand.cs
+++ b/DisCatSharp.ApplicationCommands/Entities/RegisteredDiscordApplicationCommand.cs
@@ -96,25 +96,27 @@ public sealed class RegisteredDiscordApplicationCommand : DiscordApplicationComm
 
 	/// <summary>
 	/// The method that will be executed when somebody runs this command.
-	/// <see langword="null"/> if command is a group command.
+	/// <see langword="null"/> if command is a group command or reflection failed.
 	/// </summary>
 	public MethodInfo? CommandMethod { get; internal set; }
 
 
 	/// <summary>
 	/// The type that contains the sub commands of this command.
-	/// <see langword="null"/> if command is not a group command.
+	/// <see langword="null"/> if command is not a group command or reflection failed.
 	/// </summary>
 	public Type? CommandType { get; internal set; }
 
 
 	/// <summary>
 	/// The type this command is contained in.
+	/// <see langword="null"/> if reflection failed.
 	/// </summary>
 	public Type? ContainingType { get; internal set; }
 
 	/// <summary>
 	/// Gets all Non-DisCatSharp attributes this command has.
+	/// <see langword="null"/> if reflection failed.
 	/// </summary>
 	public IReadOnlyList<Attribute>? CustomAttributes { get; internal set; }
 }

--- a/DisCatSharp.ApplicationCommands/Entities/RegisteredDiscordApplicationCommand.cs
+++ b/DisCatSharp.ApplicationCommands/Entities/RegisteredDiscordApplicationCommand.cs
@@ -1,0 +1,102 @@
+// This file is part of the DisCatSharp project.
+//
+// Copyright (c) 2021-2023 AITSYS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using DisCatSharp.Entities;
+using DisCatSharp.Enums;
+
+namespace DisCatSharp.ApplicationCommands.Entities;
+
+/// <summary>
+/// Represents a discord application command registered by the ApplicationCommands extensions.
+/// </summary>
+public sealed class RegisteredDiscordApplicationCommand : DiscordApplicationCommand
+{
+	/// <summary>
+	/// Creates a new empty registered discord application command.
+	/// </summary>
+	internal RegisteredDiscordApplicationCommand() { }
+
+	/// <summary>
+	/// Creates a new registered discord application command to control a dildo. (Lala told me to leave it)
+	/// </summary>
+	/// <param name="parent"></param>
+	internal RegisteredDiscordApplicationCommand(DiscordApplicationCommand parent)
+	{
+		this.AdditionalProperties = parent.AdditionalProperties;
+		this.ApplicationId = parent.ApplicationId;
+		this.DefaultMemberPermissions = parent.DefaultMemberPermissions;
+		this.Description = parent.Description;
+		this.Discord = parent.Discord;
+		this.DmPermission = parent.DmPermission;
+		this.Id = parent.Id;
+		this.IgnoredJsonKeys = parent.IgnoredJsonKeys;
+		this.IsNsfw = parent.IsNsfw;
+		this.Name = parent.Name;
+		this.Options = parent.Options;
+		this.RawDescriptionLocalizations = parent.RawDescriptionLocalizations;
+		this.RawNameLocalizations = parent.RawNameLocalizations;
+		this.Type = parent.Type;
+		this.UnknownProperties = parent.UnknownProperties;
+		this.Version = parent.Version;
+	}
+
+	/// <summary>
+	/// The method that will be executed when somebody runs this command.
+	/// </summary>
+	public MethodInfo CommandMethod
+	{
+		get
+		{
+			var methodInfo = ApplicationCommandsExtension.s_commandMethods.FirstOrDefault(x => x.CommandId == this.Id, null)?.Method;
+			methodInfo ??= ApplicationCommandsExtension.s_contextMenuCommands.FirstOrDefault(x => x.CommandId == this.Id, null)?.Method;
+			methodInfo ??= ApplicationCommandsExtension.s_groupCommands.FirstOrDefault(x => x.CommandId == this.Id, null)?.Methods.First().Value;
+
+			return methodInfo;
+		}
+	}
+
+
+	/// <summary>
+	/// The type this command is contained in.
+	/// </summary>
+	public Type ContainingType
+		=> this.CommandMethod.DeclaringType;
+
+	/// <summary>
+	/// Gets all Non-DisCatSharp attributes this command has.
+	/// </summary>
+	public IReadOnlyList<Attribute> CustomAttributes
+	{
+		get
+		{
+			this._customAttributes ??= this.CommandMethod.GetCustomAttributes().Where(x => !x.GetType().Namespace.StartsWith("DisCatSharp")).ToList();
+			return this._customAttributes.AsReadOnly();
+		}
+	}
+
+	private List<Attribute> _customAttributes = null;
+}

--- a/DisCatSharp/Entities/Application/DiscordApplicationCommand.cs
+++ b/DisCatSharp/Entities/Application/DiscordApplicationCommand.cs
@@ -33,7 +33,7 @@ namespace DisCatSharp.Entities;
 /// <summary>
 /// Represents a command that is registered to an application.
 /// </summary>
-public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<DiscordApplicationCommand>
+public class DiscordApplicationCommand : SnowflakeObject, IEquatable<DiscordApplicationCommand>
 {
 	/// <summary>
 	/// Gets the type of this application command.
@@ -184,6 +184,11 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
 		this.IsNsfw = isNsfw;
 		//this.Contexts = contexts;
 	}
+
+	/// <summary>
+	/// Creates a new empty Discord Application Command.
+	/// </summary>
+	internal DiscordApplicationCommand() { }
 
 	/// <summary>
 	/// Checks whether this <see cref="DiscordApplicationCommand"/> object is equal to another object.

--- a/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
+++ b/DisCatSharp/Entities/Application/DiscordApplicationCommandOption.cs
@@ -33,7 +33,7 @@ namespace DisCatSharp.Entities;
 /// <summary>
 /// Represents a parameter for a <see cref="DiscordApplicationCommand"/>.
 /// </summary>
-public sealed class DiscordApplicationCommandOption
+public class DiscordApplicationCommandOption
 {
 	/// <summary>
 	/// Gets the type of this command parameter.
@@ -180,4 +180,9 @@ public sealed class DiscordApplicationCommandOption
 		this.RawNameLocalizations = nameLocalizations?.GetKeyValuePairs();
 		this.RawDescriptionLocalizations = descriptionLocalizations?.GetKeyValuePairs();
 	}
+
+	/// <summary>
+	/// Creates a new empty DiscordApplicationCommandOption.
+	/// </summary>
+	internal DiscordApplicationCommandOption() { }
 }


### PR DESCRIPTION
Adds the `RegisteredDiscordApplicationCommand` which inherits `DiscordApplicationCommand`.

This child type adds 4 new properties: `CommandMethod`, `CommandType`, `ContainingType` and `CustomAttributes` to allow developers to embed more information into their commands. For example, for a custom help command.