### PR TITLE
make opus encoder/decoder public

### DIFF
--- a/DisCatSharp.VoiceNext/Codec/Opus.cs
+++ b/DisCatSharp.VoiceNext/Codec/Opus.cs
@@ -6,7 +6,7 @@ namespace DisCatSharp.VoiceNext.Codec;
 /// <summary>
 /// The opus.
 /// </summary>
-internal sealed class Opus : IDisposable
+internal class Opus : IDisposable
 {
 	/// <summary>
 	/// Gets the audio format.


### PR DESCRIPTION
This makes Opus encoder decoder public. In projects that deal with audio, I need to encode or decode Opus and it seems odd to include another separate library when DisCatSharp already has a wrapper for libopus.

There is no downside of making it public because it is independent and extra instances cannot break anything.
