### PR TITLE
Fix minor voiceNext issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -189,39 +189,39 @@ csharp_preserve_single_line_statements = true
 
 # Naming rules
 
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = hint
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 
-dotnet_naming_rule.private_static_readonly_fields_convention.severity = error
+dotnet_naming_rule.private_static_readonly_fields_convention.severity = hint
 dotnet_naming_rule.private_static_readonly_fields_convention.symbols = private_static_fields_readonly
 dotnet_naming_rule.private_static_readonly_fields_convention.style = private_static_camel_case
 
-dotnet_naming_rule.private_static_fields_convention.severity = error
+dotnet_naming_rule.private_static_fields_convention.severity = hint
 dotnet_naming_rule.private_static_fields_convention.symbols = private_static_field_props
 dotnet_naming_rule.private_static_fields_convention.style = private_static_camel_case
 
-dotnet_naming_rule.readonly.severity = error
+dotnet_naming_rule.readonly.severity = hint
 dotnet_naming_rule.readonly.symbols = readonly
 dotnet_naming_rule.readonly.style = underscore_prefixed_camel_case
 
-dotnet_naming_rule.private_field_should_be_underscore_prefixed_camel_case.severity = error
+dotnet_naming_rule.private_field_should_be_underscore_prefixed_camel_case.severity = hint
 dotnet_naming_rule.private_field_should_be_underscore_prefixed_camel_case.symbols = private_fields
 dotnet_naming_rule.private_field_should_be_underscore_prefixed_camel_case.style = underscore_prefixed_camel_case
 
-dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.severity = hint
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.const_fields_should_be_all_upper.severity = error
+dotnet_naming_rule.const_fields_should_be_all_upper.severity = hint
 dotnet_naming_rule.const_fields_should_be_all_upper.symbols = const_fields
 dotnet_naming_rule.const_fields_should_be_all_upper.style = constant_style
 
-dotnet_naming_rule.constants_should_be_upper_case.severity = error
+dotnet_naming_rule.constants_should_be_upper_case.severity = hint
 dotnet_naming_rule.constants_should_be_upper_case.symbols = constants
 dotnet_naming_rule.constants_should_be_upper_case.style = constant_style
 
-dotnet_naming_rule.private_props_not_allowed.severity = error
+dotnet_naming_rule.private_props_not_allowed.severity = hint
 dotnet_naming_rule.private_props_not_allowed.symbols = private_prop
 dotnet_naming_rule.private_props_not_allowed.style = constant_style
 

--- a/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
+++ b/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
@@ -28,6 +28,7 @@ Manual Download: https://docs.dcs.aitsys.dev/natives/index.html
 
   <ItemGroup>
     <Content Include="runtimes/**/*.*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>true</Pack>
       <PackagePath>runtimes</PackagePath>
     </Content>

--- a/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
+++ b/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
@@ -26,13 +26,21 @@ Manual Download: https://docs.dcs.aitsys.dev/natives/index.html
 	<Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="runtimes/**/*.*">
+
+	<ItemGroup Condition=" '$(IncludeAssets)' == '' ">
+		<!-- Logic for normal build -->
+		<Content Include="runtimes/**/*.*">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>true</Pack>
-      <PackagePath>runtimes</PackagePath>
-    </Content>
-  </ItemGroup>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(IncludeAssets)' != '' ">
+		<!-- Logic for NuGet packing -->
+		<Content Include="runtimes/**/*.*">
+			<Pack>true</Pack>
+			<PackagePath>runtimes</PackagePath>
+		</Content>
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="DisCatSharp.Analyzer.Roselyn" Version="6.1.0">

--- a/DisCatSharp.VoiceNext/VoiceNextConnection.cs
+++ b/DisCatSharp.VoiceNext/VoiceNextConnection.cs
@@ -655,6 +655,8 @@ public sealed class VoiceNextConnection : IDisposable
 				// user isn't present as we haven't received a speaking event yet.
 				User = null
 			};
+
+			_transmittingSsrCs.TryAdd(ssrc, vtx);
 		}
 
 		voiceSender = vtx;

--- a/DisCatSharp/Entities/User/DiscordUser.cs
+++ b/DisCatSharp/Entities/User/DiscordUser.cs
@@ -562,12 +562,16 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
 	/// <param name="e1">First user to compare.</param>
 	/// <param name="e2">Second user to compare.</param>
 	/// <returns>Whether the two users are equal.</returns>
-	public static bool operator ==(DiscordUser e1, DiscordUser e2)
+	public static bool operator ==(DiscordUser? e1, DiscordUser? e2)
 	{
 		var o1 = e1 as object;
 		var o2 = e2 as object;
 
-		return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || e1.Id == e2.Id);
+		if (o1 is null && o2 is null) return true;
+		if (o1 is null || o2 is null) // one of them is null
+			return false;
+
+		return e1.Id == e2.Id;
 	}
 
 	/// <summary>
@@ -576,7 +580,7 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
 	/// <param name="e1">First user to compare.</param>
 	/// <param name="e2">Second user to compare.</param>
 	/// <returns>Whether the two users are not equal.</returns>
-	public static bool operator !=(DiscordUser e1, DiscordUser e2)
+	public static bool operator !=(DiscordUser? e1, DiscordUser? e2)
 		=> !(e1 == e2);
 }
 


### PR DESCRIPTION
# Description

This PR fixes issue, where if bot joins a channel that already has people, and those people speak, their voice stutters first time they talk and is ok next time.

It happens because discord sends player joined event only AFTER person stops speaking first time. This means we don't have entry in _transmittingSsrCs and current logic kept recreating it on every packet leading to wrong gap/invalid order packet logic.

This PR also fixes naming issues (which exists in current repo) be labeled as errors (problem in jetbrains rider for example) and fixes DiscordUser comparison for nullable references.

Also voice next native auto copies dlls to bin for easier local testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested by using voice from the bot with another project.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
