### PR TITLE
Update commands.md

### DIFF
--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/commands.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/commands.md
@@ -96,7 +96,7 @@ public class MyFirstLavalinkCommands : BaseCommandModule
 	}
 
 	[SlashCommand("leave", "Leave the voice channel")]
-	public async Task LeaveAsync(InteractionContext ctx)
+	public async Task LeaveAsync(InteractionContext ctx, DiscordChannel channel)
 	{
 		await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
 		var lavalink = ctx.Client.GetLavalink();

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/commands.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/commands.md
@@ -77,13 +77,13 @@ public class MyFirstLavalinkCommands : BaseCommandModule
 	{
 		await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
 		var lavalink = ctx.Client.GetLavalink();
-		if (!lava.ConnectedSessions.Any())
+		if (!lavalink.ConnectedSessions.Any())
 		{
 			await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent("The Lavalink connection is not established"));
 			return;
 		}
 
-		var session = lava.ConnectedSessions.Values.First();
+		var session = lavalink.ConnectedSessions.Values.First();
 
 		if (channel.Type != ChannelType.Voice || channel.Type != ChannelType.Stage)
 		{


### PR DESCRIPTION
# Description

Fixed a small typo in the example code while, `var lavalink` is called `lava` function is used instead which doesn't allow for code to run. Also, added `DiscordChannel channel` in the parameter as to call `channel.Mention` in the code.

## Type of change

- [X] This change requires a documentation update

@Aiko-IT-Systems/discatsharp
