### PR TITLE
refactor: Obsolete Timeout Events

### DIFF
--- a/DisCatSharp/Clients/DiscordClient.Events.cs
+++ b/DisCatSharp/Clients/DiscordClient.Events.cs
@@ -360,14 +360,15 @@ public sealed partial class DiscordClient
 
 	private AsyncEvent<DiscordClient, GuildBanRemoveEventArgs> _guildBanRemoved;
 
-#endregion
+	#endregion
 
-#region Guild Timeout
+	#region Guild Timeout
 
 	/// <summary>
 	/// Fired when a guild member timeout gets added.
 	/// For this Event you need the <see cref="DiscordIntents.GuildModeration"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
 	/// </summary>
+	[Obsolete("This event is not actually fired. Use GuildMemberUpdated instead.")]
 	public event AsyncEventHandler<DiscordClient, GuildMemberTimeoutAddEventArgs> GuildMemberTimeoutAdded
 	{
 		add => this._guildMemberTimeoutAdded.Register(value);
@@ -380,6 +381,7 @@ public sealed partial class DiscordClient
 	/// Fired when a guild member timeout gets changed.
 	/// For this Event you need the <see cref="DiscordIntents.GuildMembers"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
 	/// </summary>
+	[Obsolete("This event is not actually fired. Use GuildMemberUpdated instead.")]
 	public event AsyncEventHandler<DiscordClient, GuildMemberTimeoutUpdateEventArgs> GuildMemberTimeoutChanged
 	{
 		add => this._guildMemberTimeoutChanged.Register(value);
@@ -392,6 +394,7 @@ public sealed partial class DiscordClient
 	/// Fired when a guild member timeout gets removed.
 	/// For this Event you need the <see cref="DiscordIntents.GuildMembers"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
 	/// </summary>
+	[Obsolete("This event is not actually fired. Use GuildMemberUpdated instead.")]
 	public event AsyncEventHandler<DiscordClient, GuildMemberTimeoutRemoveEventArgs> GuildMemberTimeoutRemoved
 	{
 		add => this._guildMemberTimeoutRemoved.Register(value);


### PR DESCRIPTION
The timeout events never actually get invoked and GuildMemberUpdated does the job. I marked these as obsolete to avoid a breaking change. We could also just remove them (or make them functional lol).