### PR TITLE
Adding Termux Hosting To Docs

### DIFF
--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -88,7 +88,7 @@ cd repo
 dotnet run
 ```
 >[!WARNING]
-> You will get an error code `0x8007000E` to fix run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc` file.
+> You will get an error code `0x8007000E` to fix run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc` file. You may also get a huge error message about a "valid ICU package" to fix that run, `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again.
 
 ## Profit
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -38,7 +38,7 @@ If you don't have a PC or other gear sitting around, you may use your phone inst
 ```sh
 pkg update && pkg upgrade -y
 ```
->[!NOTE]
+>[!TIP]
 > It might ask you for input, just click enter and let the default option be executed.
 
 - Install proot-distro package.
@@ -114,19 +114,19 @@ cd repo
 
 - Now, exit out of Debian and into normal Termux and make a new environment variable which leads us to the VM's root directory. Run, `export PROOTDISTROFS=/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs` and run `source $HOME/.bashrc`.
 
->[!NOTE]
+>[!TIP]
 > If you don't have a `.bashrc` file in your $HOME, just run `nano $HOME/.bashrc`, save, and exit. Then run the source command again.
 
 - Now, we'll move over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
 
->[!NOTE]
+>[!WARNING]
 > Double-check file paths, as you might accidentally move the wrong files around.
 
 - Now, let's log back into Debian `proot-distro login debian` and check if the files are here. To check, you can run `ls` to list the current content of the folder.
 
 - Add your configuration file then build the project.
 
->[!NOTE]
+>[!CAUTION]
 > If you have folders such as `bin/` and `obj/` from your prior builds on your PC, delete those by running `rm -rf bin/ obj/`. You might run into issues otherwise.
 
 #### Profit

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -109,7 +109,7 @@ cd repo
 - Double click on `Phone` or what it is named, then simply copy your project folder from your pc and paste it in there. If you want to keep it in a custom path, remember the path to the project.
 
 >[!NOTE]
-> Transferring of files will take a bit and be sure to not interrupt the process by shutting down any devices or disconnecting.
+> Transferring of files might take a bit. Be sure to not interrupt the process by shutting down or disconnecting your phone
 
 - First, we setup Termux storage run, `termux-setup-storage` and then it'll prompt you to give Termux access to your files and folders. Then run, `ls ~/storage/shared` to make sure you have access.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -80,7 +80,7 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dot
 
 >[!WARNING]
 > You might encounter the error code `0x8007000E` when you try to run the bot. To fix it, run `export DOTNET_GCHeapHardLimit=1C0000000` and also put that command into your `~/.bashrc` file. 
->> You'll possibly also get hit with an error message about a "valid ICU package" to fix that, run `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
+> You'll possibly also get hit with an error message about a "valid ICU package" to fix that, run `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
 ```xml
 <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
 ```

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -79,7 +79,9 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dot
 > If the script doesn't automatically add `dotnet` to the path environment variable, run `export PATH=$PATH:$HOME/.dotnet` and add this command to the end of your `.bashrc` file which can be found in your user directory. To edit the `.bashrc` file run, `nano ~/.bashrc` and paste in the arguments. The `.bashrc` file is your configuration file for the bash shell environment.
 
 >[!WARNING]
-> You will get an error code `0x8007000E` when you try to run it to fix it run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `~/.bashrc` file. You may also get a huge error message about a "valid ICU package" to fix that run, `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
+> You might encounter the error code `0x8007000E` when you try to run the bot. To fix it, run `export DOTNET_GCHeapHardLimit=1C0000000` and also put that command into your `~/.bashrc` file. 
+
+You'll possibly also get hit with an error message about a "valid ICU package" to fix that, run `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
 ```xml
 <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
 ```

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -119,7 +119,7 @@ cd repo
 >[!NOTE]
 >  If you do not have a `.bashrc` in your `$HOME` just run, `nano $HOME/.bashrc`, save and exit. Then run, the source command again.
 
-- Now, let's ove over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
+- Now, we'll move over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
 
 >[!NOTE]
 > Double, check for file path's as you may accidentally move the wrong files around.

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -8,7 +8,7 @@ author: DisCatSharp Team
 
 ## Free hosting
 
-If you're looking for free hosts, you've likely considered using [Heroku](https://www.heroku.com/) or [Glitch](https://glitch.com/).
+If you're looking for free hosts, you've likely considered using [Glitch](https://glitch.com/).
 We advise against using these platforms as they are designed to host web services, not Discord bots, and instances from either of these companies will shut down if there isn't enough internet traffic.
 Save yourself the headache and don't bother.
 
@@ -22,24 +22,24 @@ Any modern hardware will work just fine, new or used.
 
 Depending on how complex your bot is, you may even consider purchasing a Raspberry Pi ($35).
 
-# Termux
+### Termux
 
 If you don't have a PC or other gear sitting around, you may use your phone instead. Using [Termux](https://termux.dev/en/) and a program called [proot-distro](https://github.com/termux/proot-distro), we create a Debian virtual machine and configure DotNET to run the bot. For anyone interested, the instructions are detailed below:
 
-## Requirements
+#### Requirements
 
 - A phone with Android 7 or higher (5+ is possible but, not recommended as it posses security issues).
 - Termux.
 - An internet connection.
 
-## Setup
+#### Setup
 
 - Initialize Termux.
 ```sh
 pkg update && pkg upgrade -y
 ```
 >[!NOTE]
-> It might ask you for input, just click enter and let the default option execute.
+> It might ask you for input, just click enter and let the default option be executed.
 
 - Install proot-distro package.
 ```sh
@@ -53,7 +53,7 @@ proot-distro install debian
 >[!NOTE]
 > Installation time for anything will depend on your internet speed.
 
-- Login into Debian and initialize Debian.
+- Login into Debian and initialize it.
 ```sh
 proot-distro login debian
 ```
@@ -85,7 +85,7 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dot
 <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
 ```
 
-### Cloud Hosted Code
+##### Cloud Hosted Code
 
 - If you have your code hosted with git or simply are able to download it, get the source code and `cd` into the directory. Example of a git repository on GitHub:
 ```sh
@@ -94,7 +94,7 @@ cd repo
 ```
 - Add your configuration file then build the project.
 
-### Local Source Code
+##### Local Source Code
 
 - If you do not have your source code hosted remotely, you can move the source code inside the VM by following the given steps: 
 
@@ -129,9 +129,9 @@ cd repo
 >[!NOTE]
 > If you have folders such as `bin/` and `obj/` from your prior builds on your PC, delete those by running `rm -rf bin/ obj/`. You might run into issues otherwise.
 
-## Profit
+#### Profit
 
-Bot should be working fine, given you follow appropriate steps. For support or any inquires you can join the DisCatSharp [Discord](https://discord.com/invite/2HWta4GXus).
+Bot should be working fine, given you follow appropriate steps. For support or any inquires you can join our discord.
 
 ## Third-Party Hosting
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -126,7 +126,7 @@ cd repo
 >[!NOTE]
 > Double-check file paths, as you might accidentally move the wrong files around.
 
-- Now, let's login back to Debian `proot-distro login debian` and check if it's here. To check, run `ls` and if you need `projectname` in the list then it's there. From here.
+- Now, let's log back into Debian `proot-distro login debian` and check if the files are here. To check, you can run `ls` to list the current content of the folder.
 
 - Add your configuration file then build the project.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -24,11 +24,11 @@ Depending on how complex your bot is, you may even consider purchasing a Raspber
 
 # Termux
 
-For those who don't have some PC or other hardware lying around alternatively you could use your phone. Using [Termux](https://termux.dev/en/) and a package called [proot-distro](https://github.com/termux/proot-distro), which we use to install a Debian vm and setup DotNET to run the bot. To those interested the steps are given below:
+If you don't have a PC or other gear sitting around, you may use your phone instead. Using [Termux](https://termux.dev/en/) and a program called [proot-distro](https://github.com/termux/proot-distro), we create a Debian virtual machine and configure DotNET to run the bot. For anyone interested, the instructions are detailed below:
 
 ## Requirements
 
-- An Android 5+
+- An Android 5+ (7+ is recommended)
 - Termux
 - An internet connection
 
@@ -38,48 +38,61 @@ For those who don't have some PC or other hardware lying around alternatively yo
 ```sh
 pkg update && pkg upgrade -y
 ```
-*Note, it might ask you for input, just click enter and let the default option execute*
+>[!NOTE]
+> It might ask you for input, just click enter and let the default option execute.
 
 - Install proot-distro package
 ```sh
 pkg install proot-distro -y
 ```
 
-- Install a Ubuntu vm
+- Install a Debian Virtual Machine (VM)
 ```sh
-proot-distro install ubuntu -y
+proot-distro install debian
 ```
-*Note, it may take a bit depending on your internet speed*
+>[!NOTE]
+> Installation time for anything will depend on your internet speed.
 
-- Login into Ubuntu and initialize Ubuntu
+- Login into Debian and initialize Debian
 ```sh
-proot-distro login ubuntu
+proot-distro login debian
 ```
 ```sh
-apt-get update -y && apt-get upgrade -y
+apt update -y && apt upgrade -y
 ```
-*Note, it may take a bit depending on your internet speed*
 
-- Update and install git and sdk
+- Update and install git and wget
 ```sh
-apt-get update -y && apt-get install -y dotnet-sdk-8.0 git -y
+apt update -y && apt install git wget -y
 ```
-*Note, will take a bit*
 
-- Clone the repo where your bot source code is and cd into it
+- Get the DotNET script
 ```sh
-git clone https://github.com/KristalliDev/alpine.git
-cd alpine
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dotnet-install.sh
 ```
-- Add your configuration file and run the project
+
+- Now, we install the sdk and runtime
+```sh
+./dotnet-install.sh --channel 8.0 --channel 8.0
+```
+>[!WARNING]
+> The script doesn't automatically add it to path so, run `export PATH=$PATH:$HOME/.dotnet` and keep it in your `.bashrc` file.
+
+- Clone your repo and cd into it
+```sh
+git clone https://github.com/username/repo.git
+cd repo
+```
+- Add your configuration file then build the project
 ```sh
 dotnet run
 ```
-**Note, you may get an error code `0x8007000E` to fix type `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc`**
+>[!WARNING]
+> You will get an error code `0x8007000E` to fix run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc` file.
 
 ## Profit
 
-Bot should be working fine, given you follow appropriate steps. For support or any inquires you can join the DisCatSharp [Discord](https://discord.com/invite/2HWta4GXus) or create an [Issue](https://github.com/Aiko-IT-Systems/DisCatSharp/issues).
+Bot should be working fine, given you follow appropriate steps. For support or any inquires you can join the DisCatSharp [Discord](https://discord.com/invite/2HWta4GXus).
 
 ## Third-Party Hosting
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -117,7 +117,7 @@ cd repo
 - Now, exit out of Debian and into normal Termux and make a new environment variable which leads us to the VM's root directory. Run, `export PROOTDISTROFS=/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs` and run `source $HOME/.bashrc`.
 
 >[!NOTE]
->  If you do not have a `.bashrc` in your `$HOME` just run, `nano $HOME/.bashrc`, save and exit. Then run, the source command again.
+> If you don't have a `.bashrc` file in your $HOME, just run `nano $HOME/.bashrc`, save, and exit. Then run the source command again.
 
 - Now, we'll move over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -76,7 +76,7 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dot
 ./dotnet-install.sh --channel 8.0
 ```
 >[!NOTE]
-> The script doesn't automatically add DotNET to path so run, `export PATH=$PATH:$HOME/.dotnet` and keep it in your `.bashrc` file which can be found in your `~` directory. To edit the `.bashrc` file run, `nano ~/.bashrc` and paste in the arguments. The `.bashrc` file is your configuration file for the bash shell environment.
+> If the script doesn't automatically add `dotnet` to the path environment variable, run `export PATH=$PATH:$HOME/.dotnet` and add this command to the end of your `.bashrc` file which can be found in your user directory. To edit the `.bashrc` file run, `nano ~/.bashrc` and paste in the arguments. The `.bashrc` file is your configuration file for the bash shell environment.
 
 >[!WARNING]
 > You will get an error code `0x8007000E` when you try to run it to fix it run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `~/.bashrc` file. You may also get a huge error message about a "valid ICU package" to fix that run, `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -122,7 +122,7 @@ cd repo
 - Now, we'll move over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
 
 >[!NOTE]
-> Double, check for file path's as you may accidentally move the wrong files around.
+> Double-check file paths, as you might accidentally move the wrong files around.
 
 - Now, let's login back to Debian `proot-distro login debian` and check if it's here. To check, run `ls` and if you need `projectname` in the list then it's there. From here.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -80,8 +80,7 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dot
 
 >[!WARNING]
 > You might encounter the error code `0x8007000E` when you try to run the bot. To fix it, run `export DOTNET_GCHeapHardLimit=1C0000000` and also put that command into your `~/.bashrc` file. 
-
-You'll possibly also get hit with an error message about a "valid ICU package" to fix that, run `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
+>> You'll possibly also get hit with an error message about a "valid ICU package" to fix that, run `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
 ```xml
 <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
 ```

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -22,6 +22,65 @@ Any modern hardware will work just fine, new or used.
 
 Depending on how complex your bot is, you may even consider purchasing a Raspberry Pi ($35).
 
+# Termux
+
+For those who don't have some PC or other hardware lying around alternatively you could use your phone. Using [Termux](https://termux.dev/en/) and a package called [proot-distro](https://github.com/termux/proot-distro), which we use to install a Debian vm and setup DotNET to run the bot. To those interested the steps are given below:
+
+## Requirements
+
+- An Android 5+
+- Termux
+- An internet connection
+
+## Setup
+
+- Initialize Termux
+```sh
+pkg update && pkg upgrade -y
+```
+*Note, it might ask you for input, just click enter and let the default option execute*
+
+- Install proot-distro package
+```sh
+pkg install proot-distro -y
+```
+
+- Install a Ubuntu vm
+```sh
+proot-distro install ubuntu -y
+```
+*Note, it may take a bit depending on your internet speed*
+
+- Login into Ubuntu and initialize Ubuntu
+```sh
+proot-distro login ubuntu
+```
+```sh
+apt-get update -y && apt-get upgrade -y
+```
+*Note, it may take a bit depending on your internet speed*
+
+- Update and install git and sdk
+```sh
+apt-get update -y && apt-get install -y dotnet-sdk-8.0 git -y
+```
+*Note, will take a bit*
+
+- Clone the repo where your bot source code is and cd into it
+```sh
+git clone https://github.com/KristalliDev/alpine.git
+cd alpine
+```
+- Add your configuration file and run the project
+```sh
+dotnet run
+```
+**Note, you may get an error code `0x8007000E` to fix type `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc`**
+
+## Profit
+
+Bot should be working fine, given you follow appropriate steps. For support or any inquires you can join the DisCatSharp [Discord](https://discord.com/invite/2HWta4GXus) or create an [Issue](https://github.com/Aiko-IT-Systems/DisCatSharp/issues).
+
 ## Third-Party Hosting
 
 The simplest, and probably most hassle-free (and maybe cheapest in the long run for dedicated machines) option is to find a provider

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -61,9 +61,9 @@ proot-distro login debian
 apt update -y && apt upgrade -y
 ```
 
-- Update and install git and wget
+- Install git and wget
 ```sh
-apt update -y && apt install git wget -y
+apt install git wget -y
 ```
 
 - Get the DotNET script

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -28,32 +28,32 @@ If you don't have a PC or other gear sitting around, you may use your phone inst
 
 ## Requirements
 
-- An Android 5+ (7+ is recommended)
-- Termux
-- An internet connection
+- An Android 7+ phone (5+ is possible but, not recommended as it posses security issues).
+- Termux.
+- An internet connection.
 
 ## Setup
 
-- Initialize Termux
+- Initialize Termux.
 ```sh
 pkg update && pkg upgrade -y
 ```
 >[!NOTE]
 > It might ask you for input, just click enter and let the default option execute.
 
-- Install proot-distro package
+- Install proot-distro package.
 ```sh
 pkg install proot-distro -y
 ```
 
-- Install a Debian Virtual Machine (VM)
+- Install a Debian Virtual Machine (VM).
 ```sh
 proot-distro install debian
 ```
 >[!NOTE]
 > Installation time for anything will depend on your internet speed.
 
-- Login into Debian and initialize Debian
+- Login into Debian and initialize Debian.
 ```sh
 proot-distro login debian
 ```
@@ -61,34 +61,75 @@ proot-distro login debian
 apt update -y && apt upgrade -y
 ```
 
-- Install git and wget
+- Install git and wget.
 ```sh
 apt install git wget -y
 ```
 
-- Get the DotNET script
+- We get the DotNET script.
 ```sh
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && chmod +x ./dotnet-install.sh
 ```
 
-- Now, we install the sdk and runtime
+- Now, we install the DotNET sdk and runtime.
 ```sh
-./dotnet-install.sh --channel 8.0 --channel 8.0
+./dotnet-install.sh --channel 8.0
 ```
->[!WARNING]
-> The script doesn't automatically add it to path so, run `export PATH=$PATH:$HOME/.dotnet` and keep it in your `.bashrc` file.
+>[!NOTE]
+> The script doesn't automatically add DotNET to path so run, `export PATH=$PATH:$HOME/.dotnet` and keep it in your `.bashrc` file which can be found in your `~` directory. To edit the `.bashrc` file run, `nano ~/.bashrc` and paste in the arguments. The `.bashrc` file is your configuration file for the bash shell environment.
 
-- Clone your repo and cd into it
+>[!WARNING]
+> You will get an error code `0x8007000E` when you try to run it to fix it run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `~/.bashrc` file. You may also get a huge error message about a "valid ICU package" to fix that run, `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again. Or simply add these lines to your `.csproj` file in your project folder:
+```xml
+<RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+```
+
+### Cloud Hosted Code
+
+- If you have your code hosted with git or simply are able to download it, get the source code and `cd` into the directory. Example of a git repository on GitHub:
 ```sh
 git clone https://github.com/username/repo.git
 cd repo
 ```
-- Add your configuration file then build the project
-```sh
-dotnet run
-```
+- Add your configuration file then build the project.
+
+### Local Source Code
+
+- If you do not have your code hosted with git let's move the code inside the VM by following the given steps: 
+
+- Enable developer options on your phone, find out [here](https://developer.android.com/studio/debug/dev-options) and also enable USB debugging which you can do by going inside `Settings > Developer options > USB debugging` or where ever your phone's is located.
+
+- Find the option `Default USB configuration` and choose `Transferring files`. Disconnect your phone from the usb and reconnect it again.
+
+> [!NOTE]
+> A prompt should come up saying a new device is connected to the PC which is the phone. Go to `This PC` on Windows and double click on your device.
+
+- Double click on `Phone` or what it is named, then simply copy your project folder from your pc and paste it in there. If you want to keep it in a custom path, remember the path to the project.
+
+>[!NOTE]
+> Transferring of files will take a bit and be sure to not interrupt the process by shutting down any devices or disconnecting.
+
+- First, we setup Termux storage run, `termux-setup-storage` and then it'll prompt you to give Termux access to your files and folders. Then run, `ls ~/storage/shared` to make sure you have access.
+
 >[!WARNING]
-> You will get an error code `0x8007000E` to fix run, `export DOTNET_GCHeapHardLimit=1C0000000` and also put that in your `.bashrc` file. You may also get a huge error message about a "valid ICU package" to fix that run, `export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` and run the bot again.
+> If you do not give Termux access to your files and folders, nothing will work going from here on.
+
+- Now, exit out of Debian and into normal Termux and make a new environment variable which leads us to the VM's root directory. Run, `export PROOTDISTROFS=/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs` and run `source $HOME/.bashrc`.
+
+>[!NOTE]
+>  If you do not have a `.bashrc` in your `$HOME` just run, `nano $HOME/.bashrc`, save and exit. Then run, the source command again.
+
+- Now, let's ove over the source code from our phone to the VM. Simply, run, `mv projectname/ $PROOTDISTROFS/debian/root/`.
+
+>[!NOTE]
+> Double, check for file path's as you may accidentally move the wrong files around.
+
+- Now, let's login back to Debian `proot-distro login debian` and check if it's here. To check, run `ls` and if you need `projectname` in the list then it's there. From here.
+
+- Add your configuration file then build the project.
+
+>[!NOTE]
+> If you have folders such as `bin/` and `obj/` from your prior builds on Windows, delete those by running, `rm -rf bin/ obj/` as without doing so, will result in an error. 
 
 ## Profit
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -103,9 +103,6 @@ cd repo
 
 - Find the option `Default USB configuration` and choose `Transferring files`. Disconnect your phone from the usb and reconnect it again.
 
-> [!NOTE]
-> A prompt should come up saying a new device is connected to the PC which is the phone. Go to `This PC` on Windows and double click on your device.
-
 - Double click on `Phone` or what it is named, then simply copy your project folder from your pc and paste it in there. If you want to keep it in a custom path, remember the path to the project.
 
 >[!NOTE]

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -97,7 +97,7 @@ cd repo
 
 ### Local Source Code
 
-- If you do not have your code hosted with git let's move the code inside the VM by following the given steps: 
+- If you do not have your source code hosted remotely, you can move the source code inside the VM by following the given steps: 
 
 - Enable developer options on your phone, find out [here](https://developer.android.com/studio/debug/dev-options) and also enable USB debugging which you can do by going inside `Settings > Developer options > USB debugging` or where ever your phone's is located.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -28,7 +28,7 @@ If you don't have a PC or other gear sitting around, you may use your phone inst
 
 ## Requirements
 
-- An Android 7+ phone (5+ is possible but, not recommended as it posses security issues).
+- A phone with Android 7 or higher (5+ is possible but, not recommended as it posses security issues).
 - Termux.
 - An internet connection.
 

--- a/DisCatSharp.Docs/articles/misc/hosting.md
+++ b/DisCatSharp.Docs/articles/misc/hosting.md
@@ -131,7 +131,7 @@ cd repo
 - Add your configuration file then build the project.
 
 >[!NOTE]
-> If you have folders such as `bin/` and `obj/` from your prior builds on Windows, delete those by running, `rm -rf bin/ obj/` as without doing so, will result in an error. 
+> If you have folders such as `bin/` and `obj/` from your prior builds on your PC, delete those by running `rm -rf bin/ obj/`. You might run into issues otherwise.
 
 ## Profit
 


### PR DESCRIPTION
Added docs for Termux hosting

# Description

Adding Termux Hosting To Documentation For Alternative Self-Hosting, this is from a thread in the Discord server with the same header.

## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

This has been tested on a samsung SM-A6060 on the latest version of Termux from F-Droid.

**Test Configuration**:
* Firmware version: -
* Hardware: samsung SM-A6060
* Toolchain: apt-get
* SDK: DotNET 8.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

@Aiko-IT-Systems/discatsharp
