### PR TITLE
[SEVERE] Fix pepegga token logger round 2 uwu

### DIFF
--- a/DisCatSharp/Net/Rest/RestClient.cs
+++ b/DisCatSharp/Net/Rest/RestClient.cs
@@ -563,7 +563,9 @@ internal sealed class RestClient : IDisposable
 				case HttpStatusCode.BadRequest:
 				case HttpStatusCode.MethodNotAllowed:
 					ex = new BadRequestException(request, response);
-					senex = new(ex.Message + "\nJson Response: " + ((ex as BadRequestException)?.JsonMessage ?? "null"), ex);
+					// remove 'ex' as the innwer exweption uwu: 'ex' contains the request information which also
+					// contains the headers, including "Authorization"! second times a charm :)
+					senex = new(ex.Message + "\nJson Response: " + ((ex as BadRequestException)?.JsonMessage ?? "null"));
 					break;
 
 				case HttpStatusCode.Unauthorized:
@@ -628,7 +630,9 @@ internal sealed class RestClient : IDisposable
 				case HttpStatusCode.ServiceUnavailable:
 				case HttpStatusCode.GatewayTimeout:
 					ex = new ServerErrorException(request, response);
-					senex = new(ex.Message + "\nJson Response: " + ((ex as ServerErrorException)!.JsonMessage ?? "null"), ex);
+					// remove 'ex' as the innwer exweption uwu: 'ex' contains the request information which also
+					// contains the headers, including "Authorization"! second times a charm :)
+					senex = new(ex.Message + "\nJson Response: " + ((ex as ServerErrorException)!.JsonMessage ?? "null"));
 					break;
 			}
 

--- a/DisCatSharp/Net/Rest/RestClient.cs
+++ b/DisCatSharp/Net/Rest/RestClient.cs
@@ -563,8 +563,7 @@ internal sealed class RestClient : IDisposable
 				case HttpStatusCode.BadRequest:
 				case HttpStatusCode.MethodNotAllowed:
 					ex = new BadRequestException(request, response);
-					// remove 'ex' as the innwer exweption uwu: 'ex' contains the request information which also
-					// contains the headers, including "Authorization"! second times a charm :)
+					// ex won't be added to avoid possible leaks
 					senex = new(ex.Message + "\nJson Response: " + ((ex as BadRequestException)?.JsonMessage ?? "null"));
 					break;
 
@@ -630,8 +629,7 @@ internal sealed class RestClient : IDisposable
 				case HttpStatusCode.ServiceUnavailable:
 				case HttpStatusCode.GatewayTimeout:
 					ex = new ServerErrorException(request, response);
-					// remove 'ex' as the innwer exweption uwu: 'ex' contains the request information which also
-					// contains the headers, including "Authorization"! second times a charm :)
+					// ex won't be added to avoid possible leaks
 					senex = new(ex.Message + "\nJson Response: " + ((ex as ServerErrorException)!.JsonMessage ?? "null"));
 					break;
 			}


### PR DESCRIPTION
So, I recently remember about #127 and sat up in my arm chair, my cigar was nearly ashed on my ashtray, I thought to myself "Surely they've done better, the library should be safe!". I pulled up my 1992 version of vim and git 1.2, cloned the repository, and started browsing. I sit there, clouded by the smoke as I browse [BaseDiscordClient](https://github.com/Aiko-IT-Systems/DisCatSharp/blob/603893017cf99ba1c889e9a1fa8f98a6be0b6263/DisCatSharp/Clients/BaseDiscordClient.cs), one property caught my attention: `Sentry`, I immediately thought of sentry exceptions and how greedy and easy it is to misconfigured sensitive information, my glasses dimmed as I browsed usages of this property... All of the sudden a certain class snuck up on me: The [RestClient](https://github.com/Aiko-IT-Systems/DisCatSharp/blob/603893017cf99ba1c889e9a1fa8f98a6be0b6263/DisCatSharp/Net/Rest/RestClient.cs), I gaze in horror as I see an exception being initialized with the request object, in awe I follow the method stack to find that sentry CAPTURES THE EXCEPTION with the request info... the humility... the horror..., my jaw drops as I realize what I stumbled upon. I immediately radio dispatch; \*static\* "We have a DEFCON 1 situation, over". 

--- 
tl;dr: if the rest client throws an exception, an [exception is created for sentry](https://github.com/Aiko-IT-Systems/DisCatSharp/blob/603893017cf99ba1c889e9a1fa8f98a6be0b6263/DisCatSharp/Net/Rest/RestClient.cs#L566) which doesn't include request info normally, BUT the original exception (containing request and response object) is passed into the sentry exception as the inner exception[^1][^2] which will leak the request object.

please fix uwu 2nd times a charm

*sidenote*: sentry seems to be leaking a lot of user data (payload data, containing user-specific content). This seems like a severe privacy issue...

[^1]: https://github.com/Aiko-IT-Systems/DisCatSharp/blob/603893017cf99ba1c889e9a1fa8f98a6be0b6263/DisCatSharp/Net/Rest/RestClient.cs#L565-L566
[^2]: https://github.com/Aiko-IT-Systems/DisCatSharp/blob/603893017cf99ba1c889e9a1fa8f98a6be0b6263/DisCatSharp/Net/Rest/RestClient.cs#L630-L631