### PR TITLE
feat: Application Emojis

### DIFF
--- a/DisCatSharp/Clients/BaseDiscordClient.cs
+++ b/DisCatSharp/Clients/BaseDiscordClient.cs
@@ -20,6 +20,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
+using Newtonsoft.Json.Linq;
+
 using Sentry;
 
 namespace DisCatSharp;
@@ -112,6 +114,11 @@ public abstract class BaseDiscordClient : IDisposable
 	/// Gets the list of available voice regions. This property is meant as a way to modify <see cref="VoiceRegions"/>.
 	/// </summary>
 	protected internal ConcurrentDictionary<string, DiscordVoiceRegion> InternalVoiceRegions { get; set; }
+
+	/// <summary>
+	/// Gets the cached application emojis for this client.
+	/// </summary>
+	public abstract IReadOnlyDictionary<ulong, DiscordApplicationEmoji> Emojis { get; }
 
 	/// <summary>
 	/// Gets the lazy voice regions.
@@ -608,6 +615,18 @@ public abstract class BaseDiscordClient : IDisposable
 	/// <param name="user">The user.</param>
 	internal bool TryGetCachedUserInternal(ulong userId, [MaybeNullWhen(false)] out DiscordUser user)
 		=> this.UserCache.TryGetValue(userId, out user);
+
+	/// <summary>
+	/// Updates the cached application emojis.
+	/// </summary>
+	/// <param name="rawEmojis">The raw emojis.</param>
+	internal abstract IReadOnlyDictionary<ulong, DiscordApplicationEmoji> UpdateCachedApplicationEmojis(JArray? rawEmojis);
+
+	/// <summary>
+	/// Updates a cached application emoji.
+	/// </summary>
+	/// <param name="emoji">The emoji.</param>
+	internal abstract DiscordApplicationEmoji UpdateCachedApplicationEmoji(DiscordApplicationEmoji emoji);
 
 	/// <summary>
 	/// Disposes this client.

--- a/DisCatSharp/DiscordConfiguration.cs
+++ b/DisCatSharp/DiscordConfiguration.cs
@@ -131,6 +131,12 @@ public sealed class DiscordConfiguration
 	public bool ReconnectIndefinitely { internal get; set; } = false;
 
 	/// <summary>
+	/// <para>Defines that the client should attempt to fetch application emojis on startup.</para>
+	/// <para>Defaults to <see langword="false"/>.</para>
+	/// </summary>
+	public bool AutoFetchApplicationEmojis { internal get; set; } = false;
+
+	/// <summary>
 	/// Sets whether the client should attempt to cache members if exclusively using unprivileged intents.
 	/// <para>
 	///     This will only take effect if there are no <see cref="DiscordIntents.GuildMembers"/> or <see cref="DiscordIntents.GuildPresences"/>
@@ -452,5 +458,6 @@ public sealed class DiscordConfiguration
 		this.IncludePrereleaseInUpdateCheck = other.IncludePrereleaseInUpdateCheck;
 		this.UpdateCheckGitHubToken = other.UpdateCheckGitHubToken;
 		this.ShowReleaseNotesInUpdateCheck = other.ShowReleaseNotesInUpdateCheck;
+		this.AutoFetchApplicationEmojis = other.AutoFetchApplicationEmojis;
 	}
 }

--- a/DisCatSharp/Entities/Application/DiscordApplicationEmoji.cs
+++ b/DisCatSharp/Entities/Application/DiscordApplicationEmoji.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+
+using DisCatSharp.Exceptions;
+
+using Newtonsoft.Json;
+
+namespace DisCatSharp.Entities;
+
+/// <summary>
+/// Represents a application emoji.
+/// </summary>
+public sealed class DiscordApplicationEmoji : DiscordEmoji
+{
+	/// <summary>
+	/// Gets the user that created the emoji (Either a team member or the bot through api).
+	/// </summary>
+	[JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]
+	public DiscordUser? User { get; internal set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DiscordApplicationEmoji"/> class.
+	/// </summary>
+	internal DiscordApplicationEmoji()
+	{ }
+
+	/// <summary>
+	/// Modifies this emoji.
+	/// </summary>
+	/// <param name="name">New name for this emoji.</param>
+	/// <returns>The modified emoji.</returns>
+	/// <exception cref="NotFoundException">Thrown when the emoji does not exist.</exception>
+	/// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+	/// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+	public Task<DiscordApplicationEmoji> ModifyAsync(string name)
+		=> this.Discord.ApiClient.ModifyApplicationEmojiAsync(this.Discord.CurrentApplication.Id, this.Id, name);
+
+	/// <summary>
+	/// Deletes this emoji.
+	/// </summary>
+	/// <exception cref="NotFoundException">Thrown when the emoji does not exist.</exception>
+	/// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+	/// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+	public Task DeleteAsync()
+		=> this.Discord.ApiClient.DeleteApplicationEmojiAsync(this.Discord.CurrentApplication.Id, this.Id);
+}

--- a/DisCatSharp/Net/Abstractions/Rest/RestApplicationPayloads.cs
+++ b/DisCatSharp/Net/Abstractions/Rest/RestApplicationPayloads.cs
@@ -69,3 +69,28 @@ internal sealed class RestApplicationModifyPayload : ObservableApiObject
 	[JsonProperty("integration_types_config", NullValueHandling = NullValueHandling.Include)]
 	public Optional<DiscordIntegrationTypesConfig?> IntegrationTypesConfig { get; set; }
 }
+
+
+/// <summary>
+/// Represents a application emoji modify payload.
+/// </summary>
+internal class RestApplicationEmojiModifyPayload : ObservableApiObject
+{
+	/// <summary>
+	/// Gets or sets the name.
+	/// </summary>
+	[JsonProperty("name")]
+	public string Name { get; set; }
+}
+
+/// <summary>
+/// Represents a application emoji create payload.
+/// </summary>
+internal sealed class RestApplicationEmojiCreatePayload : RestApplicationEmojiModifyPayload
+{
+	/// <summary>
+	/// Gets or sets the image b64.
+	/// </summary>
+	[JsonProperty("image")]
+	public string ImageB64 { get; set; }
+}

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 DisCatSharp Release Notes
 
-    None
+    - Implemented application emojis. Read more here: https://discord.com/developers/docs/change-log#application-emoji. Breaking change in 'DiscordEmoji.TryFromName' (additional required parameter).
 
 
 DisCatSharp.Attributes Release Notes


### PR DESCRIPTION
# Description

This implements [Application Emojis](https://discord.com/developers/docs/change-log#application-emoji) (THANKS MAISY).
Breaking change in `DiscordEmoji.TryFromName` (additional required parameter)

## Added methods, properties & objects
- `BaseDiscordClient.Emojis`-  (`IReadOnlyDictionary<ulong, DiscordApplicationEmoji>`)
- `DiscordClient.Emojis`-  (`IReadOnlyDictionary<ulong, DiscordApplicationEmoji>`)
- `DiscordClient.GetApplicationEmojisAsync(bool fetch = false)` - (`Task<IReadOnlyList<DiscordApplicationEmoji>>`)
- `DiscordClient.GetApplicationEmojiAsync(ulong id, bool fetch = false)` - (`Task<DiscordApplicationEmoji?>`)
- `DiscordClient.CreateApplicationEmojiAsync(string name, Stream image)` - (`Task<DiscordApplicationEmoji>`)
- `DiscordClient.ModifyApplicationEmojiAsync(ulong id, string name)` - (`Task<DiscordApplicationEmoji>`)
- `DiscordClient.DeleteApplicationEmojiAsync(ulong id)`
- `DiscordConfiguration.AutoFetchApplicationEmojis`
- `DiscordApplicationEmoji`
- `DiscordApplicationEmoji.ModifyAsync(string name)` - (`Task<DiscordApplicationEmoji>`)
- `DiscordApplicationEmoji.DeleteAsync()`
- `DiscordEmoji.FromApplicationEmote(BaseDiscordClient client, ulong id)`- (`DiscordEmoji`), can be casted to `DiscordApplicationEmoji`

## Changed methods, properties & objects
- `DiscordEmoji.RolesInternal` - Will default to `[]` meaning `RolesInternal.Roles` should never throw an NRE. Made it internal
- `DiscordEmoji.FromName(BaseDiscordClient client, string name, bool includeGuilds = true, bool includeApplication = true)` - (`DiscordEmoji`) , can be casted to `DiscordUnicodeEmoji`, `DiscordGuildEmoji` & `DiscordApplicationEmoji`
- ⚠️ `DiscordEmoji.TryFromName(BaseDiscordClient client, string name, bool includeGuilds, bool includeApplication, out DiscordEmoji emoji)` - (`DiscordEmoji`) , can be casted to `DiscordUnicodeEmoji`, `DiscordGuildEmoji` & `DiscordApplicationEmoji` |  **Breaking:** Additional required parameter `bool includeApplication`

## Additional
- Updated incorrect internal documentation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

@Aiko-IT-Systems/discatsharp
