### PR TITLE
Enhance queue management and interaction response

### DIFF
--- a/DisCatSharp.ApplicationCommands/Context/BaseContext.cs
+++ b/DisCatSharp.ApplicationCommands/Context/BaseContext.cs
@@ -160,6 +160,14 @@ public class BaseContext : DisCatSharpCommandContext
 		=> this.Interaction.EditOriginalResponseAsync(builder);
 
 	/// <summary>
+	///     Edits the interaction response.
+	/// </summary>
+	/// <param name="content">The content to edit the response with.</param>
+	/// <returns></returns>
+	public Task<DiscordMessage> EditResponseAsync(string content)
+		=> this.Interaction.EditOriginalResponseAsync(new DiscordWebhookBuilder().WithContent(content));
+
+	/// <summary>
 	///     Deletes the interaction response.
 	/// </summary>
 	/// <returns></returns>

--- a/DisCatSharp.ApplicationCommands/DisCatSharp.ApplicationCommands.csproj
+++ b/DisCatSharp.ApplicationCommands/DisCatSharp.ApplicationCommands.csproj
@@ -36,6 +36,8 @@
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.CommandsNext/DisCatSharp.CommandsNext.csproj
+++ b/DisCatSharp.CommandsNext/DisCatSharp.CommandsNext.csproj
@@ -40,11 +40,14 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/DisCatSharp.Common/DisCatSharp.Common.csproj
+++ b/DisCatSharp.Common/DisCatSharp.Common.csproj
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-		<PackageReference Include="Backport.System.Threading.Lock" Version="3.1.1" />
+		<PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -36,11 +36,14 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="9.0.30" />
 		<PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="9.0.30" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 		<PackageReference Include="System.Memory" Version="4.6.0" />
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/DisCatSharp.Configuration/DisCatSharp.Configuration.csproj
+++ b/DisCatSharp.Configuration/DisCatSharp.Configuration.csproj
@@ -31,7 +31,11 @@
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/advanced.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/advanced.md
@@ -19,8 +19,8 @@ General config:
 ```yml
 lavalink:
   plugins:
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.0.1"
-      repository: "https://maven.topi.wtf/releases"
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.3.0"
+      repository: "https://maven.lavalink.dev/releases"
 [..]
 plugins:
   lavasrc:
@@ -136,4 +136,4 @@ LavalinkLoadResult result = await guildPlayer.LoadTracksAsync(type, query);
 
 ## Conclusion
 
-This is the most basic example of how to use the new Lavalink features. You can find more information in the Lavalink plugin docs: https://github.com/topi314/LavaSrc#usage
+This is the most basic example of how to use the new Lavalink features. You can find more information in the Lavalink plugin docs: https://github.com/topi314/LavaSrc?tab=readme-ov-file#lavalink-usage

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/configuration.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/configuration.md
@@ -101,13 +101,13 @@ We are now ready to start the bot. If everything is configured properly, you sho
 And a client connection appear in your Lavalink console:
 
 ```yml
-2023-06-25 09:05:28.757  INFO 4436 --- [  XNIO-1 task-1] io.undertow.servlet                      : Initializing Spring DispatcherServlet 'dispatcherServlet'
-2023-06-25 09:05:28.758  INFO 4436 --- [  XNIO-1 task-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
-2023-06-25 09:05:28.760  INFO 4436 --- [  XNIO-1 task-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 2 ms
-2023-06-25 09:05:28.861  INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.RequestLoggingFilter  : GET /version?trace=false, client=127.0.0.1
-2023-06-25 09:05:28.876  INFO 4436 --- [  XNIO-1 task-1] l.server.io.HandshakeInterceptorImpl     : Incoming connection from /127.0.0.1:54649
-2023-06-25 09:05:28.918  INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.RequestLoggingFilter  : GET /v4/websocket, client=127.0.0.1
-2023-06-25 09:05:29.048  INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.SocketServer          : Connection successfully established from DisCatSharp.Lavalink/10.4.1
+INFO 4436 --- [  XNIO-1 task-1] io.undertow.servlet                      : Initializing Spring DispatcherServlet 'dispatcherServlet'
+INFO 4436 --- [  XNIO-1 task-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+INFO 4436 --- [  XNIO-1 task-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 2 ms
+INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.RequestLoggingFilter  : GET /version?trace=false, client=127.0.0.1
+INFO 4436 --- [  XNIO-1 task-1] l.server.io.HandshakeInterceptorImpl     : Incoming connection from /127.0.0.1:54649
+INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.RequestLoggingFilter  : GET /v4/websocket, client=127.0.0.1
+INFO 4436 --- [  XNIO-1 task-1] lavalink.server.io.SocketServer          : Connection successfully established from DisCatSharp.Lavalink/10.6.6+38c8062e7f88b2e9920a535637d4f3afccbbf205
 ```
 
 We are now ready to set up some music commands!

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/docker.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/docker.md
@@ -1,0 +1,38 @@
+---
+uid: modules_audio_lavalink_v4_docker
+title: Lavalink V4 Docker
+author: DisCatSharp Team
+---
+
+# Template for running Lavalink in Docker
+
+- Create a folder where you'd save the lavalink config and plugins. I.e. `mkdir /opt/lavalink`.
+- Follow the [Setup](xref:modules_audio_lavalink_v4_setup) instructions to create your `application.yml`. Make sure to set `0.0.0.0` as `address`.
+- Save the `application.yml` in the created folder.
+- Create a `docker-compose.yml` file like this and save it in the created folder:
+```yml
+services:
+  lavalink:
+    image: ghcr.io/lavalink-devs/lavalink:latest
+    container_name: lavalink
+    restart: unless-stopped
+    environment:
+      - _JAVA_OPTIONS=-Xmx6G
+      - SERVER_PORT=2333
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+      - ./plugins/:/opt/Lavalink/plugins/
+    networks:
+      - lavalink
+    expose:
+      - 2333
+    ports:
+      - "2333:2333"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+networks:
+  lavalink:
+    name: lavalink
+```
+- Create a folder called `plugins` in the created folder.
+- Run `docker compose up -d` to start lavalink

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
@@ -1,0 +1,184 @@
+# Lavalink Guild Player Queue System
+
+The Lavalink module provides a built-in queue system for managing audio tracks. The queue system allows you to add, remove, and manipulate tracks in a guild-specific queue.
+
+## Enabling the Queue System
+The queue system is disabled by default, To use the queue system, you must enable it in your [`LavalinkConfiguration`](../../../../../DisCatSharp.Lavalink/LavalinkConfiguration.cs):
+
+```cs
+var config = new LavalinkConfiguration
+{
+    EnableBuiltInQueueSystem = true
+};
+```
+## Basic Queue Operations
+### Adding Tracks
+You can add individual tracks or entire playlists to the queue:
+
+```cs
+// Add a single track
+guildPlayer.AddToQueue(track);
+
+// Add all tracks from a playlist
+    var loadResult = await guildPlayer.LoadTracksAsync(LavalinkSearchType.Youtube, query);
+var playlist = loadResult.GetResultAs<LavalinkPlaylist>()
+guildPlayer.AddToQueue(playlist);
+```
+
+### Playing the Queue
+To start playing tracks from the queue:
+```cs
+guildPlayer.PlayQueue();
+```
+
+The finished commands should look like so:
+```cs
+[SlashCommand("play", "Play a track")]
+public async Task PlayAsync(InteractionContext ctx, [Option("query", "The query to search for")] string query)
+{
+    await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
+    if (ctx.Member.VoiceState == null || ctx.Member.VoiceState.Channel == null)
+    {
+        await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent("You are not in a voice channel."));
+        return;
+    }
+
+    var lavalink = ctx.Client.GetLavalink();
+    var guildPlayer = lavalink.GetGuildPlayer(ctx.Guild);
+
+    if (guildPlayer == null)
+    {
+        await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent("Lavalink is not connected."));
+        return;
+    }
+
+    var loadResult = await guildPlayer.LoadTracksAsync(LavalinkSearchType.Youtube, query);
+
+    if (loadResult.LoadType == LavalinkLoadResultType.Empty || loadResult.LoadType == LavalinkLoadResultType.Error)
+    {
+        await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"Track search failed for {query}."));
+        return;
+    }
+
+    LavalinkTrack track = loadResult.LoadType switch
+    {
+        LavalinkLoadResultType.Track => loadResult.GetResultAs<LavalinkTrack>(),
+        LavalinkLoadResultType.Playlist => loadResult.GetResultAs<LavalinkPlaylist>().Tracks.First(),
+        LavalinkLoadResultType.Search => loadResult.GetResultAs<List<LavalinkTrack>>().First(),
+        _ => throw new InvalidOperationException("Unexpected load result type.")
+    };
+
+    if (guildPlayer.CurrentTrack == null)
+    {
+        guildPlayer.AddToQueue(track);
+        guildPlayer.PlayQueue();
+        await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"Now playing {query}!"));
+    }
+    else
+    {
+        guildPlayer.AddToQueue(track);
+        await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent($"Track added to queue {track.Info.Title}!"));
+    }
+}
+```
+### Skipping the Current Track
+To skip the currently playing track, you can use the `SkipAsync` method of the `LavalinkGuildPlayer` class. This method will skip the current track. If the queue system is enabled and there are more tracks in the queue, the next track will automatically start playing.
+```cs
+await guildPlayer.SkipAsync();
+```
+
+### Managing the Queue
+
+The queue system provides several other methods for managing tracks:
+```cs
+// See list queue
+guildPlayer.Queue;
+
+// Remove a specific track
+guildPlayer.RemoveQueue(track);
+
+// Remove a track by its title/identifier
+guildPlayer.RemoveQueue("song title");
+
+// Clear all tracks from the queue
+guildPlayer.ClearQueue();
+
+// Shuffle the queue
+guildPlayer.ShuffleQueue();
+
+// Reverse the queue order
+guildPlayer.ReverseQueue();
+
+...
+```
+## Queue Entry Pipeline
+The Lavalink queue system includes a powerful pipeline system that allows you to execute custom actions before and after track playback. This is implemented through the `IQueueEntry` interface.
+### Queue Entry Lifecycle
+Each track in the queue goes through the following pipeline stages:
+1. **Before Playing**: Called right before a track starts playing
+2. **Track Playback**: The actual track playback
+3. **After Playing**: Called after track playback completes
+
+### Creating Custom Queue Entries
+To create a custom queue entry, implement the `IQueueEntry` interface:
+
+```cs
+public class CustomQueueEntry : IQueueEntry
+{
+    public LavalinkTrack Track { get; set; }
+
+    public async Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player)
+    {
+        // Execute code before the track plays
+        // Return false to skip this track
+        return true;
+    }
+
+    public async Task AfterPlayingAsync(LavalinkGuildPlayer player)
+    {
+        // Execute code after the track finishes playing
+    }
+}
+```
+
+### Configuring Custom Queue Entries
+To use custom queue entries, configure them in your `LavalinkConfiguration`:
+```cs
+var config = new LavalinkConfiguration
+{
+    EnableBuiltInQueueSystem = true,
+    QueueEntryFactory = () => new CustomQueueEntry()
+};
+```
+or
+```cs
+ services.AddTransient<IQueueEntry, CustomQueueEntry>();
+
+var config = new LavalinkConfiguration
+{
+    EnableBuiltInQueueSystem = true,
+    QueueEntryFactory = () => scope.ServiceProvider.GetRequiredService<IQueueEntry>
+};
+```
+In case you use dependency injection in `CustomQueueEntry`
+
+### Pipeline Flow Control
+- The `BeforePlayingAsync` method can control whether a track should be played by returning `true` or `false`
+- The `AfterPlayingAsync` method is called after the track finishes, allowing for cleanup or next-track preparation
+- Both methods have access to the `LavalinkGuildPlayer` instance for advanced control
+
+Example usage of flow control:
+```cs
+public async Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player)
+{
+    if (/* some condition */)
+    {
+        // Skip this track
+        return false;
+    }
+
+    // Play this track
+    await player.Channel.SendMessageAsync($"Track Started: {Track.Info.Title}");
+    return true;
+}
+```

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
@@ -9,7 +9,7 @@ author: DisCatSharp Team
 The Lavalink module provides a built-in queue system for managing audio tracks. The queue system allows you to add, remove, and manipulate tracks in a guild-specific queue.
 
 ## Enabling the Queue System
-The queue system is disabled by default, To use the queue system, you must enable it in your [`LavalinkConfiguration`](../../../../../DisCatSharp.Lavalink/LavalinkConfiguration.cs):
+The queue system is disabled by default, To use the queue system, you must enable it in your [`LavalinkConfiguration`](xref:DisCatSharp.Lavalink.LavalinkConfiguration):
 
 ```cs
 var config = new LavalinkConfiguration

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/queue.md
@@ -1,3 +1,9 @@
+---
+uid: modules_audio_lavalink_v4_queue_system
+title: Lavalink V4 Queue System
+author: DisCatSharp Team
+---
+
 # Lavalink Guild Player Queue System
 
 The Lavalink module provides a built-in queue system for managing audio tracks. The queue system allows you to add, remove, and manipulate tracks in a guild-specific queue.

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
@@ -103,7 +103,7 @@ plugins:
       #- deezer
       - yandexMusic
 lavalink:
-  plugins:
+  plugins: # You can find more plugins on Lavalinks official site at https://lavalink.dev/plugins
     - dependency: "dev.lavalink.youtube:youtube-plugin:1.11.3" # Source: https://github.com/lavalink-devs/youtube-source
       snapshot: false
     - dependency: "com.github.topi314.lavasearch:lavasearch-plugin:1.0.0" # Source: https://github.com/topi314/LavaSearch

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
@@ -112,9 +112,6 @@ lavalink:
     - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.3.0" # Source: https://github.com/topi314/LavaSrc
       repository: "https://maven.lavalink.dev/releases"
       snapshot: false
-    - dependency: "com.github.topi314.sponsorblock:sponsorblock-plugin:3.0.0" # Source: https://github.com/topi314/SponsorBlock-Plugin
-      repository: "https://maven.lavalink.dev/releases"
-      snapshot: false
     - dependency: "com.github.topi314.lavalyrics:lavalyrics-plugin" # Source: https://github.com/topi314/LavaLyrics
       repository: "https://maven.lavalink.dev/releases"
       snapshot: false

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
@@ -8,14 +8,14 @@ author: DisCatSharp Team
 
 ## Configuring Java
 
-In order to run Lavalink, you must have Java 17 or greater installed. For more details check the [requirements](https://github.com/lavalink-devs/Lavalink/tree/dev#requirements) before downloading.
+In order to run Lavalink, you must have Java 17 or greater installed. For more details check the [requirements](https://github.com/lavalink-devs/Lavalink/tree/master?tab=readme-ov-file#requirements) before downloading.
 The latest v17 releases can be found [here](https://www.oracle.com/java/technologies/downloads/#java17).
 
 Make sure the location of the newest JRE's bin folder is added to your system variable's path. This will make the `java` command run from the latest runtime. You can verify that you have the right version by entering `java -version` in your command prompt or terminal.
 
 ## Downloading Lavalink
 
-Download the Lavalink V4 server from the [GitHub](https://github.com/lavalink-devs/Lavalink/releases/tag/4.0.0).
+Download the Lavalink V4 server from the [GitHub](https://github.com/lavalink-devs/Lavalink/releases).
 
 To use the Lavalink server, you need to configure it first.
 
@@ -25,37 +25,111 @@ Create a new YAML file called `application.yml`, and use the [example file](http
 > For YouTube Support, see the sections `plugins -> youtube` and `lavalink -> plugins` in the config.
 
 ```yaml
-server: # REST and WS server
+server:
   port: 2333
-  address: 0.0.0.0
-plugins: # Uncomment the youtube config if you enabled the youtube plugin down below.
-#  youtube:
-#    enabled: true # Whether this source can be used.
-#    allowSearch: true # Whether "ytsearch:" and "ytmsearch:" can be used.
-#    allowDirectVideoIds: true # Whether just video IDs can match. If false, only complete URLs will be loaded.
-#    allowDirectPlaylistIds: true # Whether just playlist IDs can match. If false, only complete URLs will be loaded.
-#    # The clients to use for track loading. See below for a list of valid clients.
-#    # Clients are queried in the order they are given (so the first client is queried first and so on...)
-#    clients:
-#      - MUSIC
-#      - ANDROID_TESTSUITE
-#      - WEB
-#      - TVHTML5EMBEDDED
+  address: 127.0.0.1 # Set it to 0.0.0.0 if you run it in docker or want to share it
+  http2:
+    enabled: false # Personally we don't see any reason currently to enable it
+plugins:
+  youtube: # To read more about it's configuration visit https://github.com/lavalink-devs/youtube-source#plugin
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    clients: # We suggest using it like this, since it switches through the clients to get streams and search running
+      - M_WEB
+      - WEB
+      - MUSIC
+      - WEBEMBEDDED
+      - ANDROID_VR
+      - TV
+      - TVHTML5EMBEDDED
+    oauth: # Read https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#using-oauth-tokens for more information
+      enabled: true
+      skipInitialization: false # Set to true if you got your refresh token
+      # refreshToken: "" # Fill out after u got the refresh token
+    pot: # Read https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#using-a-potoken for more information or use this one
+      token: "CgtLYnJKeDl1N0pJMCjW2cO8BjIKCgJERRIEEgAgKg=="
+      visitorData: "MnRuJyEtJOv8LW4fImJbwY4qXcflEPdSWXwKWnQappnJt4Ee_3bFCJEUmiePXV3jvyjxMuT8pE3j-ZKoLtF-bIjo7-erKATkj38QRYgrGRsEHDC97Qk9a-tcYdXpmMQt2h6A1S325QgSsRfbfjBfBTeDq_oZBA=="
+  lavasrc: # To read more about it's configuration visit https://github.com/topi314/LavaSrc?tab=readme-ov-file
+    providers:
+      - "ytsearch:\"%ISRC%\""
+      - "ytsearch:%QUERY%"
+      - "scsearch:%QUERY%"
+      - "spsearch:%QUERY%"
+      - "sprec:%QUERY%"
+      - "ymsearch:%QUERY%"
+      #- "amsearch:%QUERY%"
+      #- "dzisrc:%ISRC%"
+      #- "dzsearch:%QUERY%"
+      - "ymsearch:%QUERY%"
+    sources:
+      spotify: true
+      applemusic: false
+      deezer: false
+      yandexmusic: true
+      flowerytts: true
+      vkmusic: false
+      youtube: true
+    lyrics-sources:
+      spotify: true
+      deezer: false
+      youtube: true
+      yandexmusic: true
+      vkmusic: false
+    spotify:
+        clientId: "" # Aquire it by visiting https://developer.spotify.com/dashboard/create
+        clientSecret: "" # Aquire it by visiting https://developer.spotify.com/dashboard/create
+        spDc: "" # Needed for lyrics, if used. Read https://github.com/topi314/LavaSrc?tab=readme-ov-file#spotify for more details.
+        playlistLoadLimit: 6
+        albumLoadLimit: 6
+        resolveArtistsInSearch: false
+        localFiles: true
+    yandexmusic:
+      accessToken: "" # Aquire it by visiting https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d
+      playlistLoadLimit: 1
+      albumLoadLimit: 1
+      artistLoadLimit: 1
+    flowerytts:
+      voice: "default voice"
+      translate: false
+      silence: 0
+      speed: 1.0
+      audioFormat: "mp3"
+  lavalyrics: # To read more about it's configuration visit https://github.com/topi314/LavaLyrics?tab=readme-ov-file#lavalink-usage
+    sources:
+      - spotify
+      - youtube
+      #- deezer
+      - yandexMusic
 lavalink:
-  plugins: # Uncomment this plugin for youtube support. Replace VERSION with the latest version from here: https://github.com/lavalink-devs/youtube-source/releases
-#    - dependency: "dev.lavalink.youtube:youtube-plugin:VERSION"
-#      repository: "https://jitpack.io"
+  plugins:
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.11.3" # Source: https://github.com/lavalink-devs/youtube-source
+      snapshot: false
+    - dependency: "com.github.topi314.lavasearch:lavasearch-plugin:1.0.0" # Source: https://github.com/topi314/LavaSearch
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.3.0" # Source: https://github.com/topi314/LavaSrc
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
+    - dependency: "com.github.topi314.sponsorblock:sponsorblock-plugin:3.0.0" # Source: https://github.com/topi314/SponsorBlock-Plugin
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
+    - dependency: "com.github.topi314.lavalyrics:lavalyrics-plugin" # Source: https://github.com/topi314/LavaLyrics
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
   server:
-    password: "youshallnotpass"
-    sources: 
-      youtube: false # Keep this at false, for youtube support see the plugins section above.
+    password: "youshallnotpassMEOW" # Set your lavalink password
+    sources:
+      youtube: false # Disabled youtube because it's not maintained anymore and got replaced by youtube-plugin
       bandcamp: true
       soundcloud: true
       twitch: true
       vimeo: true
       http: true
-      local: false
-    filters: # All filters are enabled by default
+      local: true
+      nico: true
+    filters:
       volume: true
       equalizer: true
       karaoke: true
@@ -66,28 +140,17 @@ lavalink:
       rotation: true
       channelMix: true
       lowPass: true
-    bufferDurationMs: 400 # The duration of the NAS buffer. Higher values fare better against longer GC pauses. Duration <= 0 to disable JDA-NAS. Minimum of 40ms, lower values may introduce pauses.
-    frameBufferDurationMs: 5000 # How many milliseconds of audio to keep buffered
-    opusEncodingQuality: 10 # Opus encoder quality. Valid values range from 0 to 10, where 10 is best quality but is the most expensive on the CPU.
-    resamplingQuality: LOW # Quality of resampling operations. Valid values are LOW, MEDIUM and HIGH, where HIGH uses the most CPU.
-    trackStuckThresholdMs: 10000 # The threshold for how long a track can be stuck. A track is stuck if does not return any audio data.
-    useSeekGhosting: true # Seek ghosting is the effect where whilst a seek is in progress, the audio buffer is read from until empty, or until seek is ready.
-    youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
-    playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds
+    bufferDurationMs: 400
+    frameBufferDurationMs: 5000
+    opusEncodingQuality: 10
+    resamplingQuality: MEDIUM
+    trackStuckThresholdMs: 10000
+    useSeekGhosting: true
+    youtubePlaylistLoadLimit: 6
+    playerUpdateInterval: 5
     youtubeSearchEnabled: true
     soundcloudSearchEnabled: true
     gc-warnings: true
-    #ratelimit:
-      #ipBlocks: ["1.0.0.0/8", "..."] # list of ip blocks
-      #excludedIps: ["...", "..."] # ips which should be explicit excluded from usage by lavalink
-      #strategy: "RotateOnBan" # RotateOnBan | LoadBalance | NanoSwitch | RotatingNanoSwitch
-      #searchTriggersFail: true # Whether a search 429 should trigger marking the ip as failing
-      #retryLimit: -1 # -1 = use default lavaplayer value | 0 = infinity | >0 = retry will happen this numbers times
-    #httpConfig: # Useful for blocking bad-actors from ip-grabbing your music node and attacking it, this way only the http proxy will be attacked
-      #proxyHost: "localhost" # Hostname of the proxy, (ip or domain)
-      #proxyPort: 3128 # Proxy port, 3128 is the default for squidProxy
-      #proxyUser: "" # Optional user for basic authentication fields, leave blank if you don't use basic auth
-      #proxyPassword: "" # Password for basic authentication
 
 metrics:
   prometheus:
@@ -96,11 +159,7 @@ metrics:
 
 sentry:
   dsn: ""
-  environment: ""
-#  tags:
-#    some_key: some_value
-#    another_key: another_value
-
+  environment: "dev"
 logging:
   file:
     path: ./logs/
@@ -108,6 +167,7 @@ logging:
   level:
     root: INFO
     lavalink: INFO
+    dev.lavalink.youtube.http.YoutubeOauth2Handler: INFO
 
   request:
     enabled: true
@@ -146,13 +206,18 @@ Once there, type `java -jar Lavalink.jar`. You should start seeing log output fr
 
 If everything is configured properly, you should see this appear somewhere in the log output without any errors:
 ```yml
-2023-06-25 06:56:56.474  INFO 35056 --- [           main] lavalink.server.Launcher                 : Starting Launcher using Java 11.0.16.1 on AITSYS with PID 35056 (H:\Lavalink.jar started by Lulalaby in H:\)
-2023-06-25 06:56:56.514  INFO 35056 --- [           main] lavalink.server.Launcher                 : No active profile set, falling back to 1 default profile: "default"
-2023-06-25 06:56:58.946  INFO 35056 --- [           main] lavalink.server.bootstrap.PluginManager  : Found plugin 'lavasrc' version c9aac26
-2023-06-25 06:56:59.025  INFO 35056 --- [           main] lavalink.server.bootstrap.PluginManager  : Loaded lavasrc-plugin-c9aac26.jar (29 classes)
-2023-06-25 06:56:59.426  INFO 35056 --- [           main] lavalink.server.Launcher                 : Started Launcher in 5.012 seconds (JVM running for 6.469)
-2023-06-25 06:56:59.431  INFO 35056 --- [           main] lavalink.server.Launcher                 : You can safely ignore the big red warning about illegal reflection. See https://github.com/lavalink-devs/Lavalink/issues/295
-2023-06-25 06:56:59.568  INFO 35056 --- [           main] lavalink.server.Launcher                 :
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : Starting Launcher v4.0.8 using Java 18.0.2.1 with PID 1 (/opt/Lavalink/Lavalink.jar started by lavalink in /opt/Lavalink)
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : No active profile set, falling back to 1 default profile: "default"
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Found plugin 'lavasearch-plugin' version 1.0.0
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Found plugin 'lavasrc-plugin' version 4.3.0
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Found plugin 'sponsorblock-plugin' version 3.0.0
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Found plugin 'youtube-plugin' version 1.11.3
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Loaded lavasearch-plugin-1.0.0.jar (20 classes)
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Loaded lavasrc-plugin-4.3.0.jar (168 classes)
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Loaded sponsorblock-plugin-3.0.0.jar (90 classes)
+INFO 1 --- [Lavalink] [           main] l.server.bootstrap.PluginManager         : Loaded youtube-plugin-1.11.3.jar (16 classes)
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : Started Launcher in 2.194 seconds (process running for 2.752)
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 :
 
        .   _                  _ _       _    __ _ _
       /\\ | | __ ___   ____ _| (_)_ __ | | __\ \ \ \
@@ -161,14 +226,59 @@ If everything is configured properly, you should see this appear somewhere in th
        '  |_|\__,_| \_/ \__,_|_|_|_| |_|_|\_\ / / / /
     =========================================/_/_/_/
 
-        Version:        6f62e585df6f177eb8bf8dfe965ddae4838a1e7b-SNAPSHOT
-        Build time:     26.05.2023 12:21:23 UTC
-        Branch          v4
-        Commit:         6f62e58
-        Commit time:    26.05.2023 12:20:13 UTC
-        JVM:            11.0.16.1
-        Lavaplayer      1.4.1
+        Version:        4.0.8
+        Build time:     20.09.2024 20:20:10 UTC
+        Branch          HEAD
+        Commit:         2946608
+        Commit time:    20.09.2024 20:17:58 UTC
+        JVM:            18.0.2.1
+        Lavaplayer      2.2.2
 
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : No active profile set, falling back to 1 default profile: "default"
+WARN 1 --- [Lavalink] [           main] io.undertow.websockets.jsr               : UT026010: Buffer pool was not set on WebSocketDeploymentInfo, the default pool will be used
+INFO 1 --- [Lavalink] [           main] io.undertow.servlet                      : Initializing Spring embedded WebApplicationContext
+INFO 1 --- [Lavalink] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 712 ms
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Loading LavaSrc plugin...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Youtube Source audio source manager...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Spotify search manager...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Youtube search manager...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Yandex Music search manager...
+INFO 1 --- [Lavalink] [           main] c.s.d.l.tools.GarbageCollectionMonitor   : GC monitoring enabled, reporting results every 2 minutes.
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Spotify audio source manager...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Yandex Music audio source manager...
+INFO 1 --- [Lavalink] [           main] c.g.t.lavasrc.plugin.LavaSrcPlugin       : Registering Flowery TTS audio source manager...
+2025-01-22T14:52:24.055Z  WARN 1 --- [Lavalink] [           main] d.l.youtube.plugin.ClientProvider        : Failed to resolve M_WEB into a Client
+INFO 1 --- [Lavalink] [           main] d.l.youtube.plugin.YoutubePluginLoader   : YouTube source initialised with clients: WEB, WEB_REMIX, WEB_EMBEDDED_PLAYER, ANDROID_VR, TVHTML5, TVHTML5_SIMPLY_EMBEDDED_PLAYER
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : ==================================================
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : OAUTH INTEGRATION: To give youtube-source access to your account, go to https://www.google.com/device and enter code <redacted>
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : ==================================================
+Picked up _JAVA_OPTIONS: -Xmx6G
+INFO 1 --- [Lavalink] [           main] c.g.t.s.plugin.SponsorBlockPlugin        : Loading SponsorBlock Plugin...
+INFO 1 --- [Lavalink] [           main] l.server.config.KoeConfiguration         : OS: LINUX, Arch: X86_64
+INFO 1 --- [Lavalink] [           main] l.server.config.KoeConfiguration         : Enabling JDA-NAS
+INFO 1 --- [Lavalink] [           main] c.s.l.c.natives.NativeLibraryLoader      : Native library udpqueue: loading with filter null
+INFO 1 --- [Lavalink] [           main] c.s.l.c.natives.NativeLibraryLoader      : Native library udpqueue: successfully loaded.
+2025-01-22T14:52:24.541Z  WARN 1 --- [Lavalink] [           main] l.server.config.SentryConfiguration      : Turning off sentry
+INFO 1 --- [Lavalink] [           main] io.undertow                              : starting server: Undertow - 2.3.13.Final
+INFO 1 --- [Lavalink] [           main] org.xnio                                 : XNIO version 3.8.8.Final
+INFO 1 --- [Lavalink] [           main] org.xnio.nio                             : XNIO NIO Implementation Version 3.8.8.Final
+INFO 1 --- [Lavalink] [           main] org.jboss.threads                        : JBoss Threads version 3.5.0.Final
+INFO 1 --- [Lavalink] [           main] o.s.b.w.e.undertow.UndertowWebServer     : Undertow started on port 2333 (http) with context path '/'
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : Started Launcher in 3.43 seconds (process running for 6.19)
+INFO 1 --- [Lavalink] [           main] lavalink.server.Launcher                 : Lavalink is ready to accept connections.
 ```
 
 If it does, congratulations. We are now ready to interact with it using DisCatSharp.
+
+## YouTube OAuth Token
+
+If you configured OAuth correctly, you should see the following in your logs:
+```yml
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : ==================================================
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : OAUTH INTEGRATION: To give youtube-source access to your account, go to https://www.google.com/device and enter code XXX-XXX-XXX
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : !!! DO NOT AUTHORISE WITH YOUR MAIN ACCOUNT, USE A BURNER !!!
+INFO 1 --- [Lavalink] [           main] d.l.youtube.http.YoutubeOauth2Handler    : ==================================================
+```

--- a/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
+++ b/DisCatSharp.Docs/articles/modules/audio/lavalink_v4/setup.md
@@ -27,7 +27,7 @@ Create a new YAML file called `application.yml`, and use the [example file](http
 ```yaml
 server:
   port: 2333
-  address: 127.0.0.1 # Set it to 0.0.0.0 if you run it in docker or want to share it
+  address: 127.0.0.1 # Set it to 0.0.0.0 if you run it in docker or if you want to share it
   http2:
     enabled: false # Personally we don't see any reason currently to enable it
 plugins:

--- a/DisCatSharp.Docs/articles/toc.yml
+++ b/DisCatSharp.Docs/articles/toc.yml
@@ -95,10 +95,14 @@ items:
                         uid: modules_audio_lavalink_v4_intro
                       - name: Setup
                         uid: modules_audio_lavalink_v4_setup
+                      - name: Docker
+                        uid: modules_audio_lavalink_v4_docker
                       - name: Configuration
                         uid: modules_audio_lavalink_v4_configuration
                       - name: Commands
                         uid: modules_audio_lavalink_v4_commands
+                      - name: Queue System
+                        uid: modules_audio_lavalink_v4_queue_system
                       - name: Advanced
                         uid: modules_audio_lavalink_v4_advanced
                 - name: VoiceNext

--- a/DisCatSharp.Experimental/DisCatSharp.Experimental.csproj
+++ b/DisCatSharp.Experimental/DisCatSharp.Experimental.csproj
@@ -33,7 +33,11 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.Hosting.DependencyInjection/DisCatSharp.Hosting.DependencyInjection.csproj
+++ b/DisCatSharp.Hosting.DependencyInjection/DisCatSharp.Hosting.DependencyInjection.csproj
@@ -23,7 +23,11 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.Hosting/DisCatSharp.Hosting.csproj
+++ b/DisCatSharp.Hosting/DisCatSharp.Hosting.csproj
@@ -28,12 +28,16 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/DisCatSharp.Interactivity/DisCatSharp.Interactivity.csproj
+++ b/DisCatSharp.Interactivity/DisCatSharp.Interactivity.csproj
@@ -35,7 +35,10 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.Lavalink/DisCatSharp.Lavalink.csproj
+++ b/DisCatSharp.Lavalink/DisCatSharp.Lavalink.csproj
@@ -42,11 +42,14 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/DisCatSharp.Lavalink/Entities/DefaultQueueEntry.cs
+++ b/DisCatSharp.Lavalink/Entities/DefaultQueueEntry.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace DisCatSharp.Lavalink.Entities;
+public class DefaultQueueEntry : IQueueEntry
+{
+	public LavalinkTrack Track { get; set; }
+
+	public Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player) => Task.FromResult(true);
+
+	public Task AfterPlayingAsync(LavalinkGuildPlayer player) => Task.CompletedTask;
+}

--- a/DisCatSharp.Lavalink/Entities/DefaultQueueEntry.cs
+++ b/DisCatSharp.Lavalink/Entities/DefaultQueueEntry.cs
@@ -1,11 +1,20 @@
 using System.Threading.Tasks;
 
 namespace DisCatSharp.Lavalink.Entities;
-public class DefaultQueueEntry : IQueueEntry
+
+/// <summary>
+///     Represents a default queue entry.
+/// </summary>
+public sealed class DefaultQueueEntry : IQueueEntry
 {
+	/// <inheritdoc />
 	public LavalinkTrack Track { get; set; }
 
-	public Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player) => Task.FromResult(true);
+	/// <inheritdoc />
+	public Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player)
+		=> Task.FromResult(true);
 
-	public Task AfterPlayingAsync(LavalinkGuildPlayer player) => Task.CompletedTask;
+	/// <inheritdoc />
+	public Task AfterPlayingAsync(LavalinkGuildPlayer player)
+		=> Task.CompletedTask;
 }

--- a/DisCatSharp.Lavalink/Entities/IQueueEntry.cs
+++ b/DisCatSharp.Lavalink/Entities/IQueueEntry.cs
@@ -27,10 +27,12 @@ public interface IQueueEntry
 	///     Actions to execute before this queue entry gets played.
 	///     Return <see langword="false" /> if entry shouldn't be played.
 	/// </summary>
+	/// <param name="player">The player.</param>
 	Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player);
 
 	/// <summary>
 	///     Actions to execute after this queue entry was played.
 	/// </summary>
+	/// <param name="player">The player.</param>
 	Task AfterPlayingAsync(LavalinkGuildPlayer player);
 }

--- a/DisCatSharp.Lavalink/Entities/LavalinkTrack.cs
+++ b/DisCatSharp.Lavalink/Entities/LavalinkTrack.cs
@@ -28,6 +28,12 @@ public sealed class LavalinkTrack
 	/// </summary>
 	[JsonProperty("pluginInfo")]
 	public LavalinkPluginInfo PluginInfo { get; internal set; }
+
+	/// <summary>
+	///     Gets the user info.
+	/// </summary>
+	[JsonProperty("userData")]
+	public object? UserData { get; internal set; }
 }
 
 /// <summary>

--- a/DisCatSharp.Lavalink/LavalinkConfiguration.cs
+++ b/DisCatSharp.Lavalink/LavalinkConfiguration.cs
@@ -116,7 +116,7 @@ public sealed class LavalinkConfiguration
 	///         <see cref="LavalinkExtension.GetIdealSession(DiscordVoiceRegion)" />.
 	///     </para>
 	/// </summary>
-	public DiscordVoiceRegion Region { internal get; set; }
+	public DiscordVoiceRegion? Region { internal get; set; }
 
 	/// <summary>
 	///     Sets whether the built in queue system should be used.
@@ -126,18 +126,21 @@ public sealed class LavalinkConfiguration
 
 	/// <summary>
 	///     Sets a factory function that creates queue entry objects.
-	///     This allows you to customize the type of queue entry used by the LavalinkGuildPlayer when <see cref="EnableBuiltInQueueSystem"/> is <see langword="true"/>.
-	///     If set to <see langword="null"/>, the default queue entry type (<see cref="DefaultQueueEntry"/>) will be used.
+	///     This allows you to customize the type of queue entry used by the LavalinkGuildPlayer when
+	///     <see cref="EnableBuiltInQueueSystem" /> is <see langword="true" />.
+	///     If set to <see langword="null" />, the default queue entry type (<see cref="DefaultQueueEntry" />) will be used.
 	/// </summary>
 	public Func<IQueueEntry>? QueueEntryFactory { get; set; }
 
 	/// <summary>
-	///     Gets a new instance of a queue entry object. 
-	///     The type of the object is determined by the <see cref="QueueEntryFactory"/>.
-	///     If <see cref="QueueEntryFactory"/> is <see langword="null"/>, a <see cref="DefaultQueueEntry"/> instance is returned.
-	///     This property is only used when <see cref="EnableBuiltInQueueSystem"/> is set to <see langword="true"/>.
+	///     Gets a new instance of a queue entry object.
+	///     The type of the object is determined by the <see cref="QueueEntryFactory" />.
+	///     If <see cref="QueueEntryFactory" /> is <see langword="null" />, a <see cref="DefaultQueueEntry" /> instance is
+	///     returned.
+	///     This property is only used when <see cref="EnableBuiltInQueueSystem" /> is set to <see langword="true" />.
 	/// </summary>
-	public IQueueEntry QueueEntry => (this.QueueEntryFactory ?? (() => new DefaultQueueEntry()))();
+	public IQueueEntry QueueEntry
+		=> (this.QueueEntryFactory ?? (() => new DefaultQueueEntry()))();
 
 	/// <summary>
 	///     Sets whether trace should be enabled for more detailed error responses.

--- a/DisCatSharp.Lavalink/LavalinkConfiguration.cs
+++ b/DisCatSharp.Lavalink/LavalinkConfiguration.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 
 using DisCatSharp.Entities;
+using DisCatSharp.Lavalink.Entities;
 using DisCatSharp.Net;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -49,6 +50,7 @@ public sealed class LavalinkConfiguration
 		this.EnableBuiltInQueueSystem = other.EnableBuiltInQueueSystem;
 		this.DefaultVolume = other.DefaultVolume;
 		this.EnableTrace = other.EnableTrace;
+		this.QueueEntryFactory = other.QueueEntryFactory;
 	}
 
 	/// <summary>
@@ -121,6 +123,21 @@ public sealed class LavalinkConfiguration
 	///     <para>Defaults to <see langword="false" />.</para>
 	/// </summary>
 	public bool EnableBuiltInQueueSystem { internal get; set; } = false;
+
+	/// <summary>
+	///     Sets a factory function that creates queue entry objects.
+	///     This allows you to customize the type of queue entry used by the LavalinkGuildPlayer when <see cref="EnableBuiltInQueueSystem"/> is <see langword="true"/>.
+	///     If set to <see langword="null"/>, the default queue entry type (<see cref="DefaultQueueEntry"/>) will be used.
+	/// </summary>
+	public Func<IQueueEntry>? QueueEntryFactory { get; set; }
+
+	/// <summary>
+	///     Gets a new instance of a queue entry object. 
+	///     The type of the object is determined by the <see cref="QueueEntryFactory"/>.
+	///     If <see cref="QueueEntryFactory"/> is <see langword="null"/>, a <see cref="DefaultQueueEntry"/> instance is returned.
+	///     This property is only used when <see cref="EnableBuiltInQueueSystem"/> is set to <see langword="true"/>.
+	/// </summary>
+	public IQueueEntry QueueEntry => (this.QueueEntryFactory ?? (() => new DefaultQueueEntry()))();
 
 	/// <summary>
 	///     Sets whether trace should be enabled for more detailed error responses.

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -660,7 +660,7 @@ public sealed class LavalinkGuildPlayer
 	/// </summary>
 	/// <param name="track">The next track in the queue, or null if the queue is empty.</param>
 	/// <returns>True if a track was found, false otherwise.</returns>
-	public bool TryPeekQueue(out LavalinkTrack? track)
+	public bool TryPeekQueue([NotNullWhen(true)] out LavalinkTrack? track)
 	{
 		if (QueueInternal.TryGetValue(this.GuildId, out var queue) && queue.TryPeek(out var result))
 		{

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -305,7 +305,8 @@ public sealed class LavalinkGuildPlayer
 			mdl.EncodedTrack, mdl.Identifier,
 			mdl.Position, mdl.EndTime,
 			mdl.Volume, mdl.Paused,
-			mdl.Filters
+			mdl.Filters,
+			mdl.UserData
 		).ConfigureAwait(false);
 		return this;
 	}

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -580,7 +580,7 @@ public sealed class LavalinkGuildPlayer
 		return Task.CompletedTask;
 	}
 
-	#region Queue Operations
+#region Queue Operations
 
 	/// <summary>
 	///     Adds a <see cref="LavalinkTrack" /> to the queue.
@@ -648,7 +648,7 @@ public sealed class LavalinkGuildPlayer
 	/// <summary>
 	///     Adds all tracks from a Lavalink playlist to the queue.
 	/// </summary>
-	/// <param name="playlist">The <see cref="LavalinkPlaylist"/> containing the tracks to add.</param>
+	/// <param name="playlist">The <see cref="LavalinkPlaylist" /> containing the tracks to add.</param>
 	public void AddToQueue(LavalinkPlaylist playlist)
 	{
 		foreach (var track in playlist.Tracks)
@@ -759,5 +759,5 @@ public sealed class LavalinkGuildPlayer
 		}
 	}
 
-	#endregion
+#endregion
 }

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -580,7 +580,7 @@ public sealed class LavalinkGuildPlayer
 		return Task.CompletedTask;
 	}
 
-#region Queue Operations
+	#region Queue Operations
 
 	/// <summary>
 	///     Adds a <see cref="LavalinkTrack" /> to the queue.
@@ -644,6 +644,16 @@ public sealed class LavalinkGuildPlayer
 	/// <param name="track">The track to add.</param>
 	public void AddToQueue(LavalinkTrack track)
 		=> QueueInternal.GetOrAdd(this.GuildId, new LavalinkQueue<LavalinkTrack>()).Enqueue(track);
+
+	/// <summary>
+	///     Adds all tracks from a Lavalink playlist to the queue.
+	/// </summary>
+	/// <param name="playlist">The <see cref="LavalinkPlaylist"/> containing the tracks to add.</param>
+	public void AddToQueue(LavalinkPlaylist playlist)
+	{
+		foreach (var track in playlist.Tracks)
+			this.AddToQueue(track);
+	}
 
 	/// <summary>
 	///     Attempts to retrieve the next track in the queue without removing it.
@@ -749,5 +759,5 @@ public sealed class LavalinkGuildPlayer
 		}
 	}
 
-#endregion
+	#endregion
 }

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -443,6 +443,13 @@ public sealed class LavalinkGuildPlayer
 	}
 
 	/// <summary>
+	///     Skips the current track.
+	/// </summary>
+	/// <returns>The updated guild player.</returns>
+	public Task<LavalinkGuildPlayer> SkipAsync()
+		=> this.StopAsync();
+
+	/// <summary>
 	///     Directly plays a song by url.
 	/// </summary>
 	/// <param name="url">The url to play.</param>

--- a/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
+++ b/DisCatSharp.Lavalink/LavalinkGuildPlayer.cs
@@ -159,7 +159,7 @@ public sealed class LavalinkGuildPlayer
 	/// <summary>
 	///     Gets the queue entries.
 	/// </summary>
-	[Obsolete("This property is deprecated. Use Queue instead")]
+	[Deprecated("This property is deprecated. Use Queue instead")]
 	public IReadOnlyList<IQueueEntry> QueueEntries
 		=> this._queueEntriesInternal.Values.ToList();
 

--- a/DisCatSharp.Lavalink/LavalinkQueue.cs
+++ b/DisCatSharp.Lavalink/LavalinkQueue.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DisCatSharp.Lavalink;
+
+public class LavalinkQueue<T> : IEnumerable<T>
+{
+	private readonly LinkedList<T> _list;
+
+	/// <summary>
+	/// Gets the number of elements contained in the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	public int Count
+	{
+		get
+		{
+			lock (this._list)
+			{
+				return this._list.Count;
+			}
+		}
+	}
+
+	public LavalinkQueue()
+	{
+		this._list = new LinkedList<T>();
+	}
+
+	public IEnumerator<T> GetEnumerator()
+	{
+		lock (this._list)
+		{
+			for (var node = this._list.First; node != null; node = node.Next)
+			{
+				yield return node.Value;
+			}
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+	/// <summary>
+	/// Adds an object to the end of the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	/// <param name="value">The object to add to the <see cref="LavalinkQueue{T}"/>. The value cannot be null.</param>
+	/// <exception cref="ArgumentNullException">Thrown when the value is null.</exception>
+	public void Enqueue(T value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		lock (this._list)
+		{
+			this._list.AddLast(value);
+		}
+	}
+
+	/// <summary>
+	/// Attempts to remove and return the object at the beginning of the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	/// <param name="value">When this method returns, contains the object removed from the beginning of the <see cref="LavalinkQueue{T}"/>, or the default value of <typeparamref name="T"/> if the queue is empty.</param>
+	/// <returns><see langword="true"/> if an object was successfully removed; otherwise, <see langword="false"/>.</returns>
+	public bool TryDequeue(out T value)
+	{
+		lock (this._list)
+		{
+			if (this._list.Count < 1)
+			{
+				value = default;
+				return false;
+			}
+
+			if (this._list.First == null)
+			{
+				value = default;
+				return true;
+			}
+
+			var result = this._list.First.Value;
+			if (result == null)
+			{
+				value = default;
+				return false;
+			}
+
+			this._list.RemoveFirst();
+			value = result;
+
+			return true;
+		}
+	}
+
+	/// <summary>
+	/// Attempts to return the object at the beginning of the <see cref="LavalinkQueue{T}"/> without removing it.
+	/// </summary>
+	/// <param name="value">When this method returns, contains the object at the beginning of the <see cref="LavalinkQueue{T}"/>, or the default value of <typeparamref name="T"/> if the queue is empty.</param>
+	/// <returns><see langword="true"/> if there is an object at the beginning of the <see cref="LavalinkQueue{T}"/>; otherwise, <see langword="false"/>.</returns>
+	public bool TryPeek(out T value)
+	{
+		lock (this._list)
+		{
+			if (this._list.First == null)
+			{
+				value = default;
+				return false;
+			}
+
+			value = this._list.First.Value;
+			return true;
+		}
+	}
+
+	/// <summary>
+	/// Removes the first occurrence of a specific object from the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	/// <param name="value">The object to remove from the <see cref="LavalinkQueue{T}"/>. The value cannot be null.</param>
+	/// <exception cref="ArgumentNullException">Thrown when the value is null.</exception>
+	public void Remove(T value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		lock (this._list)
+		{
+			this._list.Remove(value);
+		}
+	}
+
+	/// <summary>
+	/// Removes all elements from the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	public void Clear()
+	{
+		lock (this._list)
+		{
+			this._list.Clear();
+		}
+	}
+
+	/// <summary>
+	/// Shuffles the elements in the <see cref="LavalinkQueue{T}"/> randomly.
+	/// </summary>
+	public void Shuffle()
+	{
+		lock (this._list)
+		{
+			if (this._list.Count < 2)
+			{
+				return;
+			}
+
+			var shadow = new T[this._list.Count];
+			var i = 0;
+			for (var node = this._list.First; node is not null; node = node.Next)
+			{
+				var j = Random.Shared.Next(i + 1);
+				if (i != j)
+				{
+					shadow[i] = shadow[j];
+				}
+
+				shadow[j] = node.Value;
+				i++;
+			}
+
+			this._list.Clear();
+			foreach (var value in shadow)
+			{
+				this._list.AddLast(value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Removes the element at the specified index of the <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	/// <param name="index">The zero-based index of the element to remove.</param>
+	/// <returns>The value of the element that was removed.</returns>
+	/// <exception cref="Exception">Thrown when the node at the specified index is null.</exception>
+	public T RemoveAt(int index)
+	{
+		lock (this._list)
+		{
+			var currentNode = this._list.First;
+
+			for (var i = 0; i <= index && currentNode != null; i++)
+			{
+				if (i != index)
+				{
+					currentNode = currentNode.Next;
+					continue;
+				}
+
+				this._list.Remove(currentNode);
+				break;
+			}
+
+			return currentNode == null
+				? throw new Exception("Node was null.")
+				: currentNode.Value;
+		}
+	}
+
+	/// <summary>
+	/// Reverses the order of the elements in the entire <see cref="LavalinkQueue{T}"/>.
+	/// </summary>
+	public void Reverse()
+	{
+		lock (this._list)
+		{
+			if (this._list.Count < 2)
+			{
+				return;
+			}
+
+			LinkedList<T> reversedList = new();
+			for (var node = this._list.Last; node != null; node = node.Previous)
+			{
+				reversedList.AddLast(node.Value);
+			}
+
+			this._list.Clear();
+			foreach (var value in reversedList)
+			{
+				this._list.AddLast(value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <param name="index"></param>
+	/// <param name="count"></param>
+	/// <returns></returns>
+	/// <exception cref="ArgumentOutOfRangeException"></exception>
+	public ICollection<T> RemoveRange(int index, int count)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(index);
+		ArgumentOutOfRangeException.ThrowIfNegative(count);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(count, this.Count - index);
+
+		var tempIndex = 0;
+		var removed = new T[count];
+		lock (this._list)
+		{
+			var currentNode = this._list.First;
+			while (tempIndex != index && currentNode != null)
+			{
+				tempIndex++;
+				currentNode = currentNode.Next;
+			}
+
+			var nextNode = currentNode?.Next;
+			for (var i = 0; i < count && currentNode != null; i++)
+			{
+				var tempValue = currentNode.Value;
+				removed[i] = tempValue;
+
+				this._list.Remove(currentNode);
+				currentNode = nextNode;
+				nextNode = nextNode?.Next;
+			}
+
+			return removed;
+		}
+	}
+}

--- a/DisCatSharp.Lavalink/LavalinkQueue.cs
+++ b/DisCatSharp.Lavalink/LavalinkQueue.cs
@@ -4,12 +4,27 @@ using System.Collections.Generic;
 
 namespace DisCatSharp.Lavalink;
 
+/// <summary>
+///     Represents a queue of objects.
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public class LavalinkQueue<T> : IEnumerable<T>
 {
+	/// <summary>
+	///     Gets the internal entries.
+	/// </summary>
 	private readonly LinkedList<T> _list;
 
 	/// <summary>
-	/// Gets the number of elements contained in the <see cref="LavalinkQueue{T}"/>.
+	///     Creates a new instance of <see cref="LavalinkQueue{T}" />.
+	/// </summary>
+	public LavalinkQueue()
+	{
+		this._list = [];
+	}
+
+	/// <summary>
+	///     Gets the number of elements contained in the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
 	public int Count
 	{
@@ -22,28 +37,24 @@ public class LavalinkQueue<T> : IEnumerable<T>
 		}
 	}
 
-	public LavalinkQueue()
-	{
-		this._list = new LinkedList<T>();
-	}
-
+	/// <inheritdoc />
 	public IEnumerator<T> GetEnumerator()
 	{
 		lock (this._list)
 		{
 			for (var node = this._list.First; node != null; node = node.Next)
-			{
 				yield return node.Value;
-			}
 		}
 	}
 
-	IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> this.GetEnumerator();
 
 	/// <summary>
-	/// Adds an object to the end of the <see cref="LavalinkQueue{T}"/>.
+	///     Adds an object to the end of the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
-	/// <param name="value">The object to add to the <see cref="LavalinkQueue{T}"/>. The value cannot be null.</param>
+	/// <param name="value">The object to add to the <see cref="LavalinkQueue{T}" />. The value cannot be null.</param>
 	/// <exception cref="ArgumentNullException">Thrown when the value is null.</exception>
 	public void Enqueue(T value)
 	{
@@ -56,30 +67,33 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Attempts to remove and return the object at the beginning of the <see cref="LavalinkQueue{T}"/>.
+	///     Attempts to remove and return the object at the beginning of the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
-	/// <param name="value">When this method returns, contains the object removed from the beginning of the <see cref="LavalinkQueue{T}"/>, or the default value of <typeparamref name="T"/> if the queue is empty.</param>
-	/// <returns><see langword="true"/> if an object was successfully removed; otherwise, <see langword="false"/>.</returns>
+	/// <param name="value">
+	///     When this method returns, contains the object removed from the beginning of the
+	///     <see cref="LavalinkQueue{T}" />, or the default value of <typeparamref name="T" /> if the queue is empty.
+	/// </param>
+	/// <returns><see langword="true" /> if an object was successfully removed; otherwise, <see langword="false" />.</returns>
 	public bool TryDequeue(out T value)
 	{
 		lock (this._list)
 		{
 			if (this._list.Count < 1)
 			{
-				value = default;
+				value = default!;
 				return false;
 			}
 
-			if (this._list.First == null)
+			if (this._list.First is null)
 			{
-				value = default;
+				value = default!;
 				return true;
 			}
 
 			var result = this._list.First.Value;
-			if (result == null)
+			if (result is null)
 			{
-				value = default;
+				value = default!;
 				return false;
 			}
 
@@ -91,17 +105,23 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Attempts to return the object at the beginning of the <see cref="LavalinkQueue{T}"/> without removing it.
+	///     Attempts to return the object at the beginning of the <see cref="LavalinkQueue{T}" /> without removing it.
 	/// </summary>
-	/// <param name="value">When this method returns, contains the object at the beginning of the <see cref="LavalinkQueue{T}"/>, or the default value of <typeparamref name="T"/> if the queue is empty.</param>
-	/// <returns><see langword="true"/> if there is an object at the beginning of the <see cref="LavalinkQueue{T}"/>; otherwise, <see langword="false"/>.</returns>
+	/// <param name="value">
+	///     When this method returns, contains the object at the beginning of the
+	///     <see cref="LavalinkQueue{T}" />, or the default value of <typeparamref name="T" /> if the queue is empty.
+	/// </param>
+	/// <returns>
+	///     <see langword="true" /> if there is an object at the beginning of the <see cref="LavalinkQueue{T}" />;
+	///     otherwise, <see langword="false" />.
+	/// </returns>
 	public bool TryPeek(out T value)
 	{
 		lock (this._list)
 		{
-			if (this._list.First == null)
+			if (this._list.First is null)
 			{
-				value = default;
+				value = default!;
 				return false;
 			}
 
@@ -111,9 +131,9 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Removes the first occurrence of a specific object from the <see cref="LavalinkQueue{T}"/>.
+	///     Removes the first occurrence of a specific object from the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
-	/// <param name="value">The object to remove from the <see cref="LavalinkQueue{T}"/>. The value cannot be null.</param>
+	/// <param name="value">The object to remove from the <see cref="LavalinkQueue{T}" />. The value cannot be null.</param>
 	/// <exception cref="ArgumentNullException">Thrown when the value is null.</exception>
 	public void Remove(T value)
 	{
@@ -126,7 +146,7 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Removes all elements from the <see cref="LavalinkQueue{T}"/>.
+	///     Removes all elements from the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
 	public void Clear()
 	{
@@ -137,16 +157,14 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Shuffles the elements in the <see cref="LavalinkQueue{T}"/> randomly.
+	///     Shuffles the elements in the <see cref="LavalinkQueue{T}" /> randomly.
 	/// </summary>
 	public void Shuffle()
 	{
 		lock (this._list)
 		{
 			if (this._list.Count < 2)
-			{
 				return;
-			}
 
 			var shadow = new T[this._list.Count];
 			var i = 0;
@@ -154,9 +172,7 @@ public class LavalinkQueue<T> : IEnumerable<T>
 			{
 				var j = Random.Shared.Next(i + 1);
 				if (i != j)
-				{
 					shadow[i] = shadow[j];
-				}
 
 				shadow[j] = node.Value;
 				i++;
@@ -164,14 +180,12 @@ public class LavalinkQueue<T> : IEnumerable<T>
 
 			this._list.Clear();
 			foreach (var value in shadow)
-			{
 				this._list.AddLast(value);
-			}
 		}
 	}
 
 	/// <summary>
-	/// Removes the element at the specified index of the <see cref="LavalinkQueue{T}"/>.
+	///     Removes the element at the specified index of the <see cref="LavalinkQueue{T}" />.
 	/// </summary>
 	/// <param name="index">The zero-based index of the element to remove.</param>
 	/// <returns>The value of the element that was removed.</returns>
@@ -182,7 +196,7 @@ public class LavalinkQueue<T> : IEnumerable<T>
 		{
 			var currentNode = this._list.First;
 
-			for (var i = 0; i <= index && currentNode != null; i++)
+			for (var i = 0; i <= index && currentNode is not null; i++)
 			{
 				if (i != index)
 				{
@@ -194,40 +208,33 @@ public class LavalinkQueue<T> : IEnumerable<T>
 				break;
 			}
 
-			return currentNode == null
-				? throw new Exception("Node was null.")
+			return currentNode is null
+				? throw new("Node was null.")
 				: currentNode.Value;
 		}
 	}
 
 	/// <summary>
-	/// Reverses the order of the elements in the entire <see cref="LavalinkQueue{T}"/>.
+	///     Reverses the order of the elements in the entire <see cref="LavalinkQueue{T}" />.
 	/// </summary>
 	public void Reverse()
 	{
 		lock (this._list)
 		{
 			if (this._list.Count < 2)
-			{
 				return;
-			}
 
 			LinkedList<T> reversedList = new();
-			for (var node = this._list.Last; node != null; node = node.Previous)
-			{
+			for (var node = this._list.Last; node is not null; node = node.Previous)
 				reversedList.AddLast(node.Value);
-			}
 
 			this._list.Clear();
 			foreach (var value in reversedList)
-			{
 				this._list.AddLast(value);
-			}
 		}
 	}
 
 	/// <summary>
-	/// 
 	/// </summary>
 	/// <param name="index"></param>
 	/// <param name="count"></param>
@@ -244,14 +251,14 @@ public class LavalinkQueue<T> : IEnumerable<T>
 		lock (this._list)
 		{
 			var currentNode = this._list.First;
-			while (tempIndex != index && currentNode != null)
+			while (tempIndex != index && currentNode is not null)
 			{
 				tempIndex++;
 				currentNode = currentNode.Next;
 			}
 
 			var nextNode = currentNode?.Next;
-			for (var i = 0; i < count && currentNode != null; i++)
+			for (var i = 0; i < count && currentNode is not null; i++)
 			{
 				var tempValue = currentNode.Value;
 				removed[i] = tempValue;

--- a/DisCatSharp.Lavalink/LavalinkQueue.cs
+++ b/DisCatSharp.Lavalink/LavalinkQueue.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DisCatSharp.Lavalink;
 
@@ -115,7 +116,7 @@ public class LavalinkQueue<T> : IEnumerable<T>
 	///     <see langword="true" /> if there is an object at the beginning of the <see cref="LavalinkQueue{T}" />;
 	///     otherwise, <see langword="false" />.
 	/// </returns>
-	public bool TryPeek(out T value)
+	public bool TryPeek([NotNullWhen(true)] out T? value)
 	{
 		lock (this._list)
 		{
@@ -125,7 +126,7 @@ public class LavalinkQueue<T> : IEnumerable<T>
 				return false;
 			}
 
-			value = this._list.First.Value;
+			value = this._list.First.Value!;
 			return true;
 		}
 	}

--- a/DisCatSharp.Lavalink/LavalinkRestClient.cs
+++ b/DisCatSharp.Lavalink/LavalinkRestClient.cs
@@ -152,7 +152,7 @@ internal sealed class LavalinkRestClient
 		if (!response.IsSuccessStatusCode)
 		{
 			var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-			var ex = LavalinkJson.DeserializeObject<LavalinkRestException>(data)!;
+			var ex = LavalinkJson.DeserializeObject<LavalinkRestException?>(data) ?? new LavalinkRestException();
 			ex.Headers = response.Headers;
 			ex.Json = data;
 			this.Discord.Logger.LogError(LavalinkEvents.LavalinkRestError, ex, "Lavalink rest encountered an exception: {data}", data);

--- a/DisCatSharp.Lavalink/LavalinkRestClient.cs
+++ b/DisCatSharp.Lavalink/LavalinkRestClient.cs
@@ -297,26 +297,34 @@ internal sealed class LavalinkRestClient
 	/// <param name="volume">The volume.</param>
 	/// <param name="paused">Whether to pause the track.</param>
 	/// <param name="filters">The filters.</param>
+	/// <param name="userData">The user data.</param>
 	/// <returns>The updated <see cref="LavalinkPlayer" /> object.</returns>
 	internal async Task<LavalinkPlayer> UpdatePlayerAsync(
 		string sessionId,
 		ulong guildId,
 		bool noReplace = false,
 		Optional<string?> encodedTrack = default,
-		Optional<string> identifier = default,
+		Optional<string?> identifier = default,
 		Optional<int> position = default,
 		Optional<int?> endTime = default,
 		Optional<int> volume = default,
 		Optional<bool> paused = default,
-		Optional<LavalinkFilters> filters = default
+		Optional<LavalinkFilters> filters = default,
+		Optional<object?> userData = default
 	)
 	{
 		var queryDict = this.GetDefaultParams();
 		queryDict.Add("noReplace", noReplace.ToString().ToLower());
 		var pld = new LavalinkRestPlayerUpdatePayload(guildId.ToString())
 		{
-			EncodedTrack = encodedTrack,
-			Identifier = identifier,
+			Track = encodedTrack.HasValue || identifier.HasValue
+				? new LavalinkRestPlayerUpdatePlayerTrackPayload()
+				{
+					Encoded = encodedTrack,
+					Identifier = identifier,
+					UserData = userData
+				}
+				: Optional.None,
 			Position = position,
 			EndTime = endTime,
 			Volume = volume,

--- a/DisCatSharp.Lavalink/LavalinkRestClient.cs
+++ b/DisCatSharp.Lavalink/LavalinkRestClient.cs
@@ -304,27 +304,32 @@ internal sealed class LavalinkRestClient
 		ulong guildId,
 		bool noReplace = false,
 		Optional<string?> encodedTrack = default,
-		Optional<string?> identifier = default,
+		Optional<string> identifier = default,
 		Optional<int> position = default,
 		Optional<int?> endTime = default,
 		Optional<int> volume = default,
 		Optional<bool> paused = default,
 		Optional<LavalinkFilters> filters = default,
-		Optional<object?> userData = default
+		Optional<object> userData = default
 	)
 	{
 		var queryDict = this.GetDefaultParams();
 		queryDict.Add("noReplace", noReplace.ToString().ToLower());
 		var pld = new LavalinkRestPlayerUpdatePayload(guildId.ToString())
 		{
-			Track = encodedTrack.HasValue || identifier.HasValue
-				? new LavalinkRestPlayerUpdatePlayerTrackPayload()
+			Track = encodedTrack.HasValue
+				? new PlayerWithEncoded
 				{
-					Encoded = encodedTrack,
-					Identifier = identifier,
-					UserData = userData
+					Encoded = encodedTrack.Value,
+					UserData = userData.HasValue ? userData.Value : null
 				}
-				: Optional.None,
+				: identifier.HasValue
+					? new PlayerWithIdentifier
+					{
+						Identifier = identifier.Value,
+						UserData = userData.HasValue ? userData.Value : null
+					}
+					: Optional<PlayerBase>.None,
 			Position = position,
 			EndTime = endTime,
 			Volume = volume,

--- a/DisCatSharp.Lavalink/Models/LavalinkPlayerUpdateModel.cs
+++ b/DisCatSharp.Lavalink/Models/LavalinkPlayerUpdateModel.cs
@@ -64,4 +64,10 @@ public sealed class LavalinkPlayerUpdateModel
 	/// </summary>
 	[JsonProperty("filters")]
 	public Optional<LavalinkFilters> Filters { internal get; set; }
+
+	/// <summary>
+	/// Gets or sets the user data.
+	/// </summary>
+	[JsonProperty("userData")]
+	public Optional<object?> UserData { get; set; }
 }

--- a/DisCatSharp.Lavalink/Models/LavalinkPlayerUpdateModel.cs
+++ b/DisCatSharp.Lavalink/Models/LavalinkPlayerUpdateModel.cs
@@ -69,5 +69,5 @@ public sealed class LavalinkPlayerUpdateModel
 	/// Gets or sets the user data.
 	/// </summary>
 	[JsonProperty("userData")]
-	public Optional<object?> UserData { get; set; }
+	public Optional<object> UserData { get; set; }
 }

--- a/DisCatSharp.Lavalink/Payloads/LavalinkRestPlayerUpdatePayload.cs
+++ b/DisCatSharp.Lavalink/Payloads/LavalinkRestPlayerUpdatePayload.cs
@@ -26,18 +26,6 @@ internal sealed class LavalinkRestPlayerUpdatePayload
 	internal string GuildId { get; set; }
 
 	/// <summary>
-	///     Gets or sets the encoded track.
-	/// </summary>
-	[JsonProperty("encodedTrack")]
-	internal Optional<string?> EncodedTrack { get; set; }
-
-	/// <summary>
-	///     Gets or sets the identifier.
-	/// </summary>
-	[JsonProperty("identifier")]
-	internal Optional<string> Identifier { get; set; }
-
-	/// <summary>
 	///     Gets or sets the start or seek position.
 	/// </summary>
 	[JsonProperty("position")]
@@ -66,4 +54,34 @@ internal sealed class LavalinkRestPlayerUpdatePayload
 	/// </summary>
 	[JsonProperty("filters")]
 	internal Optional<LavalinkFilters> Filters { get; set; }
+
+	/// <summary>
+	///    Gets or sets the track.
+	/// </summary>
+	[JsonProperty("track")]
+	internal Optional<LavalinkRestPlayerUpdatePlayerTrackPayload> Track { get; set; }
+}
+
+/// <summary>
+///    The lavalink rest player update player track payload.
+/// </summary>
+internal sealed class LavalinkRestPlayerUpdatePlayerTrackPayload
+{
+	/// <summary>
+	///     Gets or sets the encoded track.
+	/// </summary>
+	[JsonProperty("encoded")]
+	internal Optional<string?> Encoded { get; set; }
+
+	/// <summary>
+	///     Gets or sets the identifier.
+	/// </summary>
+	[JsonProperty("identifier")]
+	internal Optional<string?> Identifier { get; set; }
+
+	/// <summary>
+	/// Gets or sets the user data.
+	/// </summary>
+	[JsonProperty("userData")]
+	public Optional<object?> UserData { get; set; }
 }

--- a/DisCatSharp.Lavalink/Payloads/LavalinkRestPlayerUpdatePayload.cs
+++ b/DisCatSharp.Lavalink/Payloads/LavalinkRestPlayerUpdatePayload.cs
@@ -22,66 +22,78 @@ internal sealed class LavalinkRestPlayerUpdatePayload
 	/// <summary>
 	///     Gets or sets the guild id.
 	/// </summary>
-	[JsonProperty("guildId")]
+	[JsonProperty("guildId", NullValueHandling = NullValueHandling.Ignore)]
 	internal string GuildId { get; set; }
 
 	/// <summary>
 	///     Gets or sets the start or seek position.
 	/// </summary>
-	[JsonProperty("position")]
+	[JsonProperty("position", NullValueHandling = NullValueHandling.Ignore)]
 	internal Optional<int> Position { get; set; }
 
 	/// <summary>
 	///     Gets or sets the end time.
 	/// </summary>
-	[JsonProperty("endTime")]
+	[JsonProperty("endTime", NullValueHandling = NullValueHandling.Include)]
 	internal Optional<int?> EndTime { get; set; }
 
 	/// <summary>
 	///     Gets or sets the volume.
 	/// </summary>
-	[JsonProperty("volume")]
+	[JsonProperty("volume", NullValueHandling = NullValueHandling.Ignore)]
 	internal Optional<int> Volume { get; set; }
 
 	/// <summary>
 	///     Gets or sets whether the player is paused.
 	/// </summary>
-	[JsonProperty("paused")]
+	[JsonProperty("paused", NullValueHandling = NullValueHandling.Ignore)]
 	internal Optional<bool> Paused { get; set; }
 
 	/// <summary>
 	///     Gets or sets the filters.
 	/// </summary>
-	[JsonProperty("filters")]
+	[JsonProperty("filters", NullValueHandling = NullValueHandling.Ignore)]
 	internal Optional<LavalinkFilters> Filters { get; set; }
 
 	/// <summary>
 	///    Gets or sets the track.
 	/// </summary>
-	[JsonProperty("track")]
-	internal Optional<LavalinkRestPlayerUpdatePlayerTrackPayload> Track { get; set; }
+	[JsonProperty("track", NullValueHandling = NullValueHandling.Ignore)]
+	internal Optional<PlayerBase> Track { get; set; }
+}
+
+/// <summary>
+///   The lavalink rest player update player track payload.
+/// </summary>
+internal class PlayerBase
+{
+	/// <summary>
+	/// Gets or sets the user data.
+	/// </summary>
+	[JsonProperty("userData", NullValueHandling = NullValueHandling.Ignore)]
+	public object? UserData { get; set; }
 }
 
 /// <summary>
 ///    The lavalink rest player update player track payload.
 /// </summary>
-internal sealed class LavalinkRestPlayerUpdatePlayerTrackPayload
+internal sealed class PlayerWithIdentifier : PlayerBase
+{
+	/// <summary>
+	///     Gets or sets the identifier.
+	/// </summary>
+	[JsonProperty("identifier", NullValueHandling = NullValueHandling.Ignore)]
+	internal required string Identifier { get; set; }
+}
+
+/// <summary>
+///    The lavalink rest player update player track payload.
+/// </summary>
+internal sealed class PlayerWithEncoded : PlayerBase
 {
 	/// <summary>
 	///     Gets or sets the encoded track.
 	/// </summary>
-	[JsonProperty("encoded")]
-	internal Optional<string?> Encoded { get; set; }
-
-	/// <summary>
-	///     Gets or sets the identifier.
-	/// </summary>
-	[JsonProperty("identifier")]
-	internal Optional<string?> Identifier { get; set; }
-
-	/// <summary>
-	/// Gets or sets the user data.
-	/// </summary>
-	[JsonProperty("userData")]
-	public Optional<object?> UserData { get; set; }
+	[JsonProperty("encoded", NullValueHandling = NullValueHandling.Include)]
+	internal string? Encoded { get; set; }
 }

--- a/DisCatSharp.Targets/InternalsVisibleTo.targets
+++ b/DisCatSharp.Targets/InternalsVisibleTo.targets
@@ -28,6 +28,7 @@
 		<InternalsVisibleTo Include="DisCatSharp.Experimental" />
 		<InternalsVisibleTo Include="DisCatSharp.Extensions.OAuth2Web" />
 		<InternalsVisibleTo Include="DisCatSharp.Extensions.TwoFactorCommands" />
+		<InternalsVisibleTo Include="DisCatSharp.Extensions.SimpleMusicCommands" />
 		<InternalsVisibleTo Include="Nyaw" />
 		<InternalsVisibleTo Include="MikuSharp" />
 		<InternalsVisibleTo Include="Microsoft.DocAsCode" />

--- a/DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer/DisCatSharp.Analyzer.csproj
+++ b/DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer/DisCatSharp.Analyzer.csproj
@@ -37,12 +37,14 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" />
+		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.12.40392" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
+++ b/DisCatSharp.VoiceNext.Natives/DisCatSharp.VoiceNext.Natives.csproj
@@ -31,7 +31,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 		<PackageReference Include="System.Reflection" Version="4.3.0" />
 		<PackageReference Include="System.Runtime" Version="4.3.1" />
 	</ItemGroup>

--- a/DisCatSharp.VoiceNext/DisCatSharp.VoiceNext.csproj
+++ b/DisCatSharp.VoiceNext/DisCatSharp.VoiceNext.csproj
@@ -35,7 +35,10 @@
 		</PackageReference>
 		<PackageReference Include="DisCatSharp.Attributes" Version="10.6.6" />
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 		<PackageReference Include="System.Threading.Channels" Version="9.0.1" />
 	</ItemGroup>
 

--- a/DisCatSharp/DisCatSharp.csproj
+++ b/DisCatSharp/DisCatSharp.csproj
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-		<PackageReference Include="Backport.System.Threading.Lock" Version="3.1.1" />
+		<PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -39,12 +39,14 @@
 		<PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NuGet.Protocol" Version="6.12.1" />
 		<PackageReference Include="Octokit" Version="14.0.0" />
 		<PackageReference Include="Sentry" Version="5.0.1" />
 		<PackageReference Include="Sentry.Extensions.Logging" Version="5.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
 		<PackageReference Include="System.Memory" Version="4.6.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Net.WebSockets" Version="4.3.0" />


### PR DESCRIPTION
# Description
- Introduced a new `EditResponseAsync` method for string content.
- Created `DefaultQueueEntry` class for track playback handling.
- Updated `LavalinkConfiguration` with a customizable `QueueEntryFactory`.
- Refactored `LavalinkGuildPlayer` to utilize a static `QueueInternal` for guild-specific queues.
- Deprecated the `QueueEntries` property in favor of the new `Queue` property.
- Implemented a new thread-safe `LavalinkQueue<T>` class for queue operations.

<!-- If this relates to an aitsys.dev issue: 
Fixes {TXXX} (aitsys.dev issue)
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x]  interaction response:
I really like the short, not too long way of writing.
The `EditResponseAsync `method is used a lot and I think the input is mainly a content, so I added a method input which is string content, hope you agree.
- [x] queue management
tested the queue part with 3 servers and they work fine (only manual test, no automation test and code test).
- [x] queue entry
In case the user only wants to use Queue(`EnableBuiltInQueueSystem = true`) and does not want to use pipeline queue entry
a transient pipeline `DefaultQueueEntry` will be used.
If they want to use it, just sets a `QueueEntryFactory `function that creates queue entry objects.
We can use `QueueEntryFactory `with DI

```csharp
public record QueueEntryFactory(IEventPublisher publisher) : IQueueEntry
{
    public LavalinkTrack Track { get; set; } = default!;

    public async Task AfterPlayingAsync(LavalinkGuildPlayer player)
    {
        await player.Channel.SendMessageAsync($"Track ended: {Track.Info.Title}-{player.Guild.Name}");
    }

    public async Task<bool> BeforePlayingAsync(LavalinkGuildPlayer player)
    {
        await player.Channel.SendMessageAsync($"Track Started: {Track.Info.Title}-{player.Guild.Name}");
        await publisher.PublishAsync(new TrackStarted());

        return await Task.FromResult(true);
    }
}
```
```csharp
 services.AddTransient<IQueueEntry, Features.Tracks.Interactions.QueueEntryFactory>();
 await lavalink.ConnectAsync(new LavalinkConfiguration()
 {
     Password = options.Password,
     RestEndpoint = endpoint,
     SocketEndpoint = endpoint,
     EnableBuiltInQueueSystem = true,
     QueueEntryFactory = () => scope.ServiceProvider.GetRequiredService<IQueueEntry>
 });
```
Otherwise we can create it with delegate instance
```csharp
    await lavalink.ConnectAsync(new LavalinkConfiguration()
    {
        Password = options.Password,
        RestEndpoint = endpoint,
        SocketEndpoint = endpoint,
        EnableBuiltInQueueSystem = true,
        QueueEntryFactory = () => new Features.Tracks.Interactions.QueueEntryFactory()
    });
```
When playing the tracks it will also create a `transient` of `QueueEntryFactory`

**Test Configuration**:
* Firmware version:
* Hardware: I5-12400F, 64GB, Nvidia RTX 4070 Super
* Toolchain: window 10, visual studio, lavalink run on ubuntu 24.04
* SDK: C#.NET 9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

@Aiko-IT-Systems/discatsharp
