### PR TITLE
Stream application command permission updates

### DIFF
--- a/DisCatSharp.Docs/api/DisCatSharp.ApplicationCommands/toc.yml
+++ b/DisCatSharp.Docs/api/DisCatSharp.ApplicationCommands/toc.yml
@@ -95,6 +95,9 @@ items:
   - uid: DisCatSharp.ApplicationCommands.Attributes.DontInjectAttribute
     name: DontInjectAttribute
     type: Class
+  - uid: DisCatSharp.ApplicationCommands.Attributes.FileTypesAttribute
+    name: FileTypesAttribute
+    type: Class
   - uid: DisCatSharp.ApplicationCommands.Attributes.IAutocompleteProvider
     name: IAutocompleteProvider
     type: Interface

--- a/DisCatSharp.Docs/api/DisCatSharp/toc.yml
+++ b/DisCatSharp.Docs/api/DisCatSharp/toc.yml
@@ -974,6 +974,9 @@ items:
   - uid: DisCatSharp.Enums.ApplicationDiscoveryEligibilityFlags
     name: ApplicationDiscoveryEligibilityFlags
     type: Enum
+  - uid: DisCatSharp.Enums.ApplicationEventWebhookStatus
+    name: ApplicationEventWebhookStatus
+    type: Enum
   - uid: DisCatSharp.Enums.ApplicationExplicitContentFilter
     name: ApplicationExplicitContentFilter
     type: Enum

--- a/DisCatSharp.Tests/DisCatSharp.CopilotTests/Store/ApplicationCommandPermissionsUpdateEventRegressionTests.cs
+++ b/DisCatSharp.Tests/DisCatSharp.CopilotTests/Store/ApplicationCommandPermissionsUpdateEventRegressionTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using DisCatSharp.Entities;
+using DisCatSharp.Enums;
+using DisCatSharp.EventArgs;
+
+using Xunit;
+
+namespace DisCatSharp.Copilot.Tests.Store;
+
+public sealed class ApplicationCommandPermissionsUpdateEventRegressionTests
+{
+	[Fact]
+	public async Task ApplicationCommandPermissionsUpdateEvent_UsesGatewayPayloadWithoutFetchingCommand()
+	{
+		const ulong applicationId = 1;
+		const ulong commandId = 2;
+		const ulong guildId = 3;
+		var client = CreateClient(applicationId);
+		var permissions = new List<DiscordApplicationCommandPermission>
+		{
+			new(4, ApplicationCommandPermissionType.User, true)
+		};
+		ApplicationCommandPermissionsUpdateEventArgs? captured = null;
+		client.ApplicationCommandPermissionsUpdated += (_, args) =>
+		{
+			captured = args;
+			return Task.CompletedTask;
+		};
+
+		await client.OnApplicationCommandPermissionsUpdateAsync(permissions, commandId, guildId, applicationId);
+
+		Assert.NotNull(captured);
+		Assert.Equal(commandId, captured!.Id);
+		Assert.Equal(applicationId, captured.ApplicationId);
+		Assert.Equal(guildId, captured.Guild.Id);
+		Assert.Same(permissions[0], Assert.Single(captured.Permissions));
+		Assert.False(captured.IsApplicationWide);
+	}
+
+	[Fact]
+	public async Task ApplicationCommandPermissionsUpdateEvent_DetectsApplicationWidePermissions()
+	{
+		const ulong applicationId = 1;
+		const ulong guildId = 3;
+		var client = CreateClient(applicationId);
+		ApplicationCommandPermissionsUpdateEventArgs? captured = null;
+		client.ApplicationCommandPermissionsUpdated += (_, args) =>
+		{
+			captured = args;
+			return Task.CompletedTask;
+		};
+
+		await client.OnApplicationCommandPermissionsUpdateAsync([], applicationId, guildId, applicationId);
+
+		Assert.NotNull(captured);
+		Assert.Equal(applicationId, captured!.Id);
+		Assert.True(captured.IsApplicationWide);
+	}
+
+	private static DiscordClient CreateClient(ulong applicationId)
+	{
+		var client = new DiscordClient(new DiscordConfiguration
+		{
+			Token = "1",
+			Gateway =
+			{
+				Advanced =
+				{
+					DispatchMode = GatewayDispatchMode.SequentialHandlers
+				}
+			}
+		});
+		client.CurrentApplication = new DiscordApplication { Id = applicationId, Discord = client };
+		return client;
+	}
+}

--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -4688,25 +4688,15 @@ public sealed partial class DiscordClient
 	///     Handles the application command permissions update event.
 	/// </summary>
 	/// <param name="perms">The new permissions.</param>
-	/// <param name="channelId">The command id.</param>
+	/// <param name="targetId">The command or application id whose permissions were updated.</param>
 	/// <param name="guildId">The guild id.</param>
 	/// <param name="applicationId">The application id.</param>
-	internal async Task OnApplicationCommandPermissionsUpdateAsync(IEnumerable<DiscordApplicationCommandPermission> perms, ulong channelId, ulong guildId, ulong applicationId)
+	internal async Task OnApplicationCommandPermissionsUpdateAsync(IEnumerable<DiscordApplicationCommandPermission> perms, ulong targetId, ulong guildId, ulong applicationId)
 	{
 		if (applicationId != this.CurrentApplication.Id)
 			return;
 
 		var guild = this.InternalGetCachedGuild(guildId);
-
-		DiscordApplicationCommand cmd;
-		try
-		{
-			cmd = await this.GetGuildApplicationCommandAsync(guildId, channelId).ConfigureAwait(false);
-		}
-		catch (NotFoundException)
-		{
-			cmd = await this.GetGlobalApplicationCommandAsync(channelId).ConfigureAwait(false);
-		}
 
 		if (guild == null)
 			guild = new()
@@ -4718,7 +4708,7 @@ public sealed partial class DiscordClient
 		var ea = new ApplicationCommandPermissionsUpdateEventArgs(this.ServiceProvider)
 		{
 			Permissions = [.. perms],
-			Command = cmd,
+			Id = targetId,
 			ApplicationId = applicationId,
 			Guild = guild
 		};

--- a/DisCatSharp/EventArgs/Application/ApplicationCommandPermissionsUpdateEventArgs.cs
+++ b/DisCatSharp/EventArgs/Application/ApplicationCommandPermissionsUpdateEventArgs.cs
@@ -24,14 +24,23 @@ public sealed class ApplicationCommandPermissionsUpdateEventArgs : DiscordEventA
 	public List<DiscordApplicationCommandPermission> Permissions { get; internal set; }
 
 	/// <summary>
-	///     Gets the application command.
+	///     Gets the identifier of the command or application whose permissions were updated.
 	/// </summary>
-	public DiscordApplicationCommand Command { get; internal set; }
+	/// <remarks>
+	///     Discord uses the application id for application-wide permissions.
+	/// </remarks>
+	public ulong Id { get; internal set; }
 
 	/// <summary>
 	///     Gets the application id.
 	/// </summary>
 	public ulong ApplicationId { get; internal set; }
+
+	/// <summary>
+	///     Gets whether this update contains application-wide permissions rather than command-specific permissions.
+	/// </summary>
+	public bool IsApplicationWide
+		=> this.Id == this.ApplicationId;
 
 	/// <summary>
 	///     Gets the guild.


### PR DESCRIPTION
## Summary

- stop enriching `APPLICATION_COMMAND_PERMISSIONS_UPDATE` gateway events with REST application-command lookups
- expose the gateway payload target as `ApplicationCommandPermissionsUpdateEventArgs.Id` and add `IsApplicationWide` for `id == application_id`
- remove the misleading `channelId` parameter name and the event args' fetched `Command` property
- add regressions for command-specific and application-wide permission payloads
- include the pending DocFX API TOC refresh

## Why

Discord sends this gateway event as an application-command permissions object, not as an application-command object. The previous handler fetched the guild command first and used a `404` to fall back to the global-command endpoint. Global commands therefore produced an expected but noisy 404 and an avoidable second request. Application-wide permissions use the application ID as `id`, so neither command lookup can succeed and the gateway event could fail altogether.

The event now relays the data Discord actually provides: target ID, application ID, guild, and permissions. `IsApplicationWide` makes the documented application-wide form directly detectable.

## Documentation refresh

This includes the complete tracked DocFX refresh from a local build, which had not been run for a few days. The generated API TOCs add existing `FileTypesAttribute` and `ApplicationEventWebhookStatus` entries.

## Validation

- `dotnet test DisCatSharp.Tests/DisCatSharp.CopilotTests/DisCatSharp.CopilotTests.csproj --no-restore --filter FullyQualifiedName~ApplicationCommandPermissionsUpdateEventRegressionTests` (passed on net9.0, net10.0, and net11.0)
- `docfx DisCatSharp.Docs/docfx.json` (succeeded with 0 errors; existing TOC display-name warnings)
- `git diff --check`

References: [Discord gateway event](https://docs.discord.com/developers/events/gateway-events#application-command-permissions-update) and [permissions object](https://docs.discord.com/developers/interactions/application-commands#guild-application-command-permissions).