### PR TITLE
feat(ci|skills): Added Agent Skills and secure releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill_issue.yml
+++ b/.github/ISSUE_TEMPLATE/skill_issue.yml
@@ -1,0 +1,100 @@
+name: Skill Issue
+description: Report incorrect guidance, installation trouble, or MCP integration problems with the DisCatSharp Agent Skills
+labels: ["agent skills"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for helping improve the DisCatSharp Agent Skills. Use the normal bug
+        report for a problem in the library itself. Never include bot tokens, API
+        keys, authorization headers, private source, or other secrets.
+  - type: dropdown
+    id: category
+    attributes:
+      label: Issue category
+      options:
+        - Incorrect or outdated guidance
+        - Skill did not trigger
+        - Installation or update
+        - Documentation MCP integration
+        - Agent compatibility
+        - Other skill behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Skill
+      options:
+        - use-discatsharp
+        - maintain-discatsharp
+        - Both
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Agent platform and version
+      description: For example, Codex app 26.x or GitHub Copilot CLI 1.x.
+    validations:
+      required: true
+  - type: input
+    id: skill_version
+    attributes:
+      label: Installed skill tag or commit
+      description: For example, v10.7.1, a nightly tag, main, or a commit SHA.
+    validations:
+      required: true
+  - type: input
+    id: discatsharp_version
+    attributes:
+      label: DisCatSharp version
+      description: The package version used by the affected project, if applicable.
+  - type: dropdown
+    id: mcp
+    attributes:
+      label: Documentation MCP state
+      options:
+        - Connected and tools available
+        - Configured but not connected
+        - Not configured
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: prompt
+    attributes:
+      label: Original prompt
+      description: Include the smallest prompt that reproduces the problem.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include relevant sanitized output or tool errors.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add installation commands, links, or a minimal public reproduction if useful.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I removed bot tokens, API keys, authorization headers, and private source.
+          required: true
+        - label: I verified whether this is a skill problem rather than a DisCatSharp library bug.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,96 +1,12 @@
 ---
-applyTo: '**'
----
-# DisCatSharp Copilot Instructions
-
-## Project Architecture
-- DisCatSharp is a modular .NET library for Discord bots, split into core (`/DisCatSharp`) and feature packages (e.g., `/DisCatSharp.ApplicationCommands`, `/DisCatSharp.CommandsNext`, `/DisCatSharp.Lavalink`, `/DisCatSharp.VoiceNext`).
-- Each major feature (commands, interactivity, voice, configuration, etc.) is in its own folder/package. Shared types/utilities are in `/DisCatSharp.Common`.
-- REST API payloads and client logic are in `/DisCatSharp/Net/`.
-- Hosting and DI integration are in `/DisCatSharp.Hosting` and `/DisCatSharp.Hosting.DependencyInjection`.
-- Analyzer and tooling live in `/DisCatSharp.Tools` and `/DisCatSharp.Analyzer`.
-- Documentation is generated with DocFX from `/DisCatSharp.Docs`.
-
-## Developer Workflows
-- Build: Use `dotnet build` on the solution or individual projects. Solution files: `DisCatSharp.slnx`, `DisCatSharp.Tools.slnx`.
-- Test: Use `dotnet test` on test projects in `/DisCatSharp.Tests` (xUnit).
-- Analyzer: Custom Roslyn analyzers are in `/DisCatSharp.Analyzer` and are delivered through the `DisCatSharp.Analyzer` NuGet package.
-- Docs: Run DocFX using `docfx docfx.json` in `/DisCatSharp.Docs`.
-- PowerShell scripts for rebuilds and packaging are in `/DisCatSharp.Tools`.
-- If you use copilot, add Co-Authored-By to the commit message to credit the AI assistant. The line should be `Co-Authored-By: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>`
-
-## Coding Conventions
-
-### C# Language Version
-- The codebase uses the latest stable C# language version. You are encouraged to use modern C# features where they improve clarity, safety, or conciseness. This includes:
-  - Collection expressions (e.g., `[..source]`)
-  - Pattern matching improvements
-  - Target-typed `new()` expressions
-  - File-scoped types
-  - Required members
-  - Primary constructors
-  - Any other features available in the current C# standard
-- Prefer modern idioms and syntax, but ensure readability and maintainability for contributors.
-- Follows Microsoft C# conventions with project-specific rules:
-  - Use `Optional<T>` for optional fields/properties in REST payloads.
-  - Use `NullValueHandling = NullValueHandling.Ignore` for nullable REST properties.
-  - Add `ShouldSerialize[Property]()` for conditional serialization if needed. Especially useful for properties that should not be serialized when null.
-  - Use `JsonIgnore` for properties that should not be serialized at all.
-  - Use PascalCase for public APIs, camelCase for locals/parameters.
-  - Prefer initializer syntax for object construction.
-  - Use XML doc comments for all public APIs.
-  - Avoid breaking changes; use `[Deprecated]` attribute for deprecations.
-  - We use file-scoped namespaces for all files.
-  - Do not ever use non-file-scoped namespaces.
-  - Namespaces does not neccessarily match folder structure, but should be consistent with the project structure.
-- Async methods should use `async`/`await` unless returning a single task directly.
-- All code changes must build and pass CI before merge.
-
-## Integration & Patterns
-- Logging uses `Microsoft.Extensions.Logging.ILogger` (can swap providers).
-- DI/Hosting: Use extension methods in `/DisCatSharp.Hosting` for ASP.NET Core/Generic Host integration.
-- REST API: All REST calls go through `DiscordApiClient` in `/DisCatSharp/Net/Rest/`.
-- Sentry is used for error reporting via a centralized `ILibraryDiagnosticsSink` abstraction; see `/DisCatSharp/Telemetry/` for the sink infrastructure and `/DisCatSharp/Net/Serialization/DiscordJson.cs` for missing-field reporting.
-- Configuration classes: `DiscordConfiguration`, `CommandsNextConfiguration`, etc. (see `/DisCatSharp/Configuration/Models/`).
-
-## Examples & Templates
-- Example projects and templates are referenced in `/DisCatSharp.Docs` and the [DisCatSharp.Examples](https://github.com/Aiko-IT-Systems/DisCatSharp.Examples) repo.
-- Project templates are available for bots, web, and combined solutions.
-
-## Key Files & Directories
-- `/DisCatSharp/Net/Rest/DiscordApiClient.cs`: Core REST client logic.
-- `/DisCatSharp/Entities/`: Discord entity models.
-- `/DisCatSharp.Tests/`: Test projects for all major features.
-- `/DisCatSharp.Docs/`: DocFX documentation source.
-- `/DisCatSharp.Tools/`: Build, packaging, and helper scripts.
-- `/DisCatSharp.Analyzer/`: Custom Roslyn analyzers and code fixes.
-
-## Versioning
-- Uses custom SemVer: `{DISCORD_API_VERSION}.{MAJOR}.{MINOR}-{PATCH}`. Major changes require discussion and deprecation attributes.
-
-## Test Placement Guidelines
-
-- If you are generating or updating tests specifically to help diagnose, reproduce, or fix bugs (e.g., Copilot-generated regression or scenario tests), place them in `/DisCatSharp.Tests/DisCatSharp.CopilotTests/` and update its `.csproj` file.
-- For all other standard or feature tests, use the appropriate subfolder in `/DisCatSharp.Tests/` according to the feature or package being tested.
-
-## Release Process
-
-We use the workflow `release.yml` (located in `.github/workflows/release.yml`) to automate releases.
-To release a package, this payload is required:
-```json
-{
-  "owner": "Aiko-IT-Systems",
-  "repo": "DisCatSharp",
-  "workflow_id": "release.yml",
-  "ref": "BRANCH_NAME",
-  "inputs": {
-    "version_suffix": "TARGET_VERSION_SUFFIX",
-    "release_as_prerelease": true,
-    "packages_to_release": "DisCatSharp"
-  }
-}
-```
-
+applyTo: "**"
 ---
 
-For more, see `/CONTRIBUTING.md`, `/README.md`, and `/DisCatSharp.Docs`.
+# DisCatSharp Copilot adapter
+
+Follow the canonical repository instructions in `/AGENTS.md`.
+
+- For repository changes, load and follow `/skills/maintain-discatsharp/SKILL.md` plus only the references it routes to.
+- For consumer questions or examples, load and follow `/skills/use-discatsharp/SKILL.md`.
+- Preserve user changes and verify current DisCatSharp APIs through live source or the documentation MCP.
+- Credit Copilot-assisted commits with `Co-Authored-By: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>` when Copilot authors the change.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,12 @@ labels:
     - label: "documentation"
       files:
           - "DisCatSharp.Docs/.*"
+    - label: "agent skills"
+      files:
+          - "skills/.*"
+          - "AGENTS.md"
+          - "CLAUDE.md"
+          - "GEMINI.md"
     - label: "experimental"
       title: ^[Exp]:.*
     - label: "dependencies"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation and Agent Skills
+      labels:
+        - documentation
+        - agent skills
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: CI and Build
+      labels:
+        - ci/cd
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/release-tools.mjs
+++ b/.github/scripts/release-tools.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { appendFileSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const FAMILIES = Object.freeze({
+  DisCatSharp: Object.freeze({
+    packageId: "DisCatSharp",
+    tagPrefix: "v",
+    title: "DisCatSharp",
+  }),
+  "DisCatSharp.Attributes": Object.freeze({
+    packageId: "DisCatSharp.Attributes",
+    tagPrefix: "attributes-v",
+    title: "DisCatSharp.Attributes",
+  }),
+  "DisCatSharp.Analyzer": Object.freeze({
+    packageId: "DisCatSharp.Analyzer",
+    tagPrefix: "analyzer-v",
+    title: "DisCatSharp.Analyzer",
+  }),
+});
+
+export function validateInputs({ family, prerelease, confirmFullRelease, suffix }) {
+  if (!FAMILIES[family])
+    throw new Error(`Unsupported package family: ${family}`);
+
+  if (prerelease) {
+    if (!suffix?.trim())
+      throw new Error("A version suffix is required for a prerelease.");
+  } else {
+    if (suffix?.trim())
+      throw new Error("A stable release cannot have a version suffix.");
+    if (!confirmFullRelease)
+      throw new Error("A stable release requires confirm_full_release.");
+  }
+}
+
+export function parsePrimaryPackageVersion(fileName, family) {
+  const config = FAMILIES[family];
+  if (!config)
+    throw new Error(`Unsupported package family: ${family}`);
+
+  const id = escapeRegExp(config.packageId);
+  const match = fileName.match(new RegExp(`^${id}\\.(\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?(?:-[0-9A-Za-z.-]+)?)\\.nupkg$`));
+  return match?.[1] ?? null;
+}
+
+export function resolveMetadata({ artifactDirectory, family, prerelease, suffix }) {
+  const files = readdirSync(artifactDirectory)
+    .filter((name) => statSync(join(artifactDirectory, name)).isFile());
+  const candidates = files
+    .map((name) => ({ name, version: parsePrimaryPackageVersion(name, family) }))
+    .filter((candidate) => candidate.version !== null);
+
+  if (candidates.length !== 1)
+    throw new Error(`Expected exactly one primary ${family} package, found ${candidates.length}.`);
+
+  const version = candidates[0].version;
+  const hasPrereleaseSuffix = version.includes("-");
+  if (prerelease !== hasPrereleaseSuffix)
+    throw new Error(`Built package version ${version} does not match the requested release channel.`);
+  if (prerelease && !version.toLowerCase().endsWith(`-${suffix.toLowerCase()}`))
+    throw new Error(`Built package version ${version} does not end with the requested suffix ${suffix}.`);
+
+  const config = FAMILIES[family];
+  return {
+    version,
+    tag: `${config.tagPrefix}${version}`,
+    title: `${config.title} v${version}`,
+    primaryPackage: candidates[0].name,
+  };
+}
+
+export function selectPreviousTag({ releases, family, prerelease, currentTag }) {
+  const flattened = releases.flat?.(Infinity) ?? releases;
+  const config = FAMILIES[family];
+  if (!config)
+    throw new Error(`Unsupported package family: ${family}`);
+
+  const sameFamily = flattened
+    .filter((release) => !release.isDraft && release.tagName !== currentTag)
+    .filter((release) => tagBelongsToFamily(release.tagName, family))
+    .filter((release) => prerelease || !release.isPrerelease)
+    .sort(newestFirst);
+
+  if (sameFamily.length > 0)
+    return sameFamily[0].tagName;
+
+  if (family !== "DisCatSharp") {
+    const mainStable = flattened
+      .filter((release) => !release.isDraft && !release.isPrerelease)
+      .filter((release) => tagBelongsToFamily(release.tagName, "DisCatSharp"))
+      .sort(newestFirst);
+    return mainStable[0]?.tagName ?? null;
+  }
+
+  return null;
+}
+
+export function evaluateReleaseState(release, { tag, targetCommit }) {
+  if (release === null)
+    return "create";
+  if (release.tag_name !== tag)
+    throw new Error(`Existing release tag ${release.tag_name} does not match ${tag}.`);
+  if (release.target_commitish !== targetCommit)
+    throw new Error(`Release ${tag} targets ${release.target_commitish}, expected ${targetCommit}.`);
+  return release.draft ? "resume" : "verify";
+}
+
+export function createChecksums(artifactDirectory) {
+  const checksumName = "SHA256SUMS";
+  const files = readdirSync(artifactDirectory)
+    .filter((name) => name !== checksumName)
+    .filter((name) => statSync(join(artifactDirectory, name)).isFile())
+    .sort((left, right) => left.localeCompare(right, "en"));
+
+  if (files.length === 0)
+    throw new Error("No release artifacts were found for checksum generation.");
+
+  const lines = files.map((name) => {
+    const digest = createHash("sha256").update(readFileSync(join(artifactDirectory, name))).digest("hex");
+    return `${digest}  ${name}`;
+  });
+  writeFileSync(join(artifactDirectory, checksumName), `${lines.join("\n")}\n`, "utf8");
+  return files;
+}
+
+function newestFirst(left, right) {
+  return Date.parse(right.publishedAt ?? 0) - Date.parse(left.publishedAt ?? 0);
+}
+
+function tagBelongsToFamily(tag, family) {
+  if (family === "DisCatSharp")
+    return /^v\d/.test(tag);
+  return tag.startsWith(FAMILIES[family].tagPrefix);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseArguments(arguments_) {
+  const values = {};
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined)
+      throw new Error(`Invalid argument list near ${key ?? "<end>"}.`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+function boolean(value, name) {
+  if (value === "true")
+    return true;
+  if (value === "false")
+    return false;
+  throw new Error(`${name} must be true or false.`);
+}
+
+function writeOutputs(outputs) {
+  const text = Object.entries(outputs).map(([key, value]) => `${key}=${value ?? ""}`).join("\n");
+  if (process.env.GITHUB_OUTPUT)
+    appendFileSync(process.env.GITHUB_OUTPUT, `${text}\n`, "utf8");
+  process.stdout.write(`${JSON.stringify(outputs, null, 2)}\n`);
+}
+
+async function main() {
+  const [command, ...arguments_] = process.argv.slice(2);
+  const args = parseArguments(arguments_);
+
+  switch (command) {
+    case "validate-inputs": {
+      validateInputs({
+        family: args.family,
+        prerelease: boolean(args.prerelease, "prerelease"),
+        confirmFullRelease: boolean(args.confirm, "confirm"),
+        suffix: args.suffix,
+      });
+      break;
+    }
+    case "metadata": {
+      const outputs = resolveMetadata({
+        artifactDirectory: args.artifacts,
+        family: args.family,
+        prerelease: boolean(args.prerelease, "prerelease"),
+        suffix: args.suffix,
+      });
+      createChecksums(args.artifacts);
+      writeOutputs(outputs);
+      break;
+    }
+    case "previous-tag": {
+      const releases = JSON.parse(readFileSync(args.releases, "utf8"));
+      const previousTag = selectPreviousTag({
+        releases,
+        family: args.family,
+        prerelease: boolean(args.prerelease, "prerelease"),
+        currentTag: args.tag,
+      });
+      writeOutputs({ previous_tag: previousTag });
+      break;
+    }
+    case "release-state": {
+      const release = JSON.parse(readFileSync(args.release, "utf8"));
+      const state = evaluateReleaseState(release, { tag: args.tag, targetCommit: args.commit });
+      writeOutputs({ release_state: state });
+      break;
+    }
+    default:
+      throw new Error(`Unknown command: ${command ?? "<none>"}`);
+  }
+}
+
+if (process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/release-tools.mjs
+++ b/.github/scripts/release-tools.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from "node:crypto";
 import { appendFileSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 

--- a/.github/scripts/release-tools.test.mjs
+++ b/.github/scripts/release-tools.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createChecksums,
+  evaluateReleaseState,
+  parsePrimaryPackageVersion,
+  resolveMetadata,
+  selectPreviousTag,
+  validateInputs,
+} from "./release-tools.mjs";
+
+test("validates stable, nightly, beta, and RC inputs", () => {
+  assert.doesNotThrow(() => validateInputs({ family: "DisCatSharp", prerelease: false, confirmFullRelease: true, suffix: "" }));
+  for (const suffix of ["nightly-015", "beta.2", "rc-1"])
+    assert.doesNotThrow(() => validateInputs({ family: "DisCatSharp", prerelease: true, confirmFullRelease: false, suffix }));
+  assert.throws(() => validateInputs({ family: "DisCatSharp", prerelease: true, confirmFullRelease: false, suffix: "" }), /suffix is required/);
+  assert.throws(() => validateInputs({ family: "DisCatSharp", prerelease: false, confirmFullRelease: true, suffix: "nightly-015" }), /cannot have/);
+  assert.throws(() => validateInputs({ family: "DisCatSharp", prerelease: false, confirmFullRelease: false, suffix: "" }), /confirm_full_release/);
+});
+
+test("extracts only each family's primary package version", () => {
+  assert.equal(parsePrimaryPackageVersion("DisCatSharp.10.7.1-nightly-015.nupkg", "DisCatSharp"), "10.7.1-nightly-015");
+  assert.equal(parsePrimaryPackageVersion("DisCatSharp.ApplicationCommands.10.7.1.nupkg", "DisCatSharp"), null);
+  assert.equal(parsePrimaryPackageVersion("DisCatSharp.Attributes.2026.3.26-beta.2.nupkg", "DisCatSharp.Attributes"), "2026.3.26-beta.2");
+  assert.equal(parsePrimaryPackageVersion("DisCatSharp.Analyzer.1.0.6.1.nupkg", "DisCatSharp.Analyzer"), "1.0.6.1");
+});
+
+test("derives all tag namespaces from built artifacts", () => {
+  const cases = [
+    ["DisCatSharp", "DisCatSharp.10.7.1-nightly-015.nupkg", true, "nightly-015", "v10.7.1-nightly-015"],
+    ["DisCatSharp", "DisCatSharp.10.7.1-beta.2.nupkg", true, "beta.2", "v10.7.1-beta.2"],
+    ["DisCatSharp.Attributes", "DisCatSharp.Attributes.2026.3.26.nupkg", false, "", "attributes-v2026.3.26"],
+    ["DisCatSharp.Analyzer", "DisCatSharp.Analyzer.1.0.6.1-rc.1.nupkg", true, "rc.1", "analyzer-v1.0.6.1-rc.1"],
+  ];
+
+  for (const [family, file, prerelease, suffix, tag] of cases) {
+    withTempDirectory((directory) => {
+      writeFileSync(join(directory, file), "package");
+      assert.equal(resolveMetadata({ artifactDirectory: directory, family, prerelease, suffix }).tag, tag);
+    });
+  }
+});
+
+test("stable notes ignore nightlies while prerelease notes use the latest family release", () => {
+  const releases = [
+    release("v10.7.1-nightly-014", true, "2026-04-26"),
+    release("v10.7.1-nightly-013", true, "2026-04-21"),
+    release("v10.7.0", false, "2026-03-20"),
+    release("v10.6.7", false, "2025-02-08"),
+  ];
+  assert.equal(selectPreviousTag({ releases, family: "DisCatSharp", prerelease: true, currentTag: "v10.7.1-nightly-015" }), "v10.7.1-nightly-014");
+  assert.equal(selectPreviousTag({ releases, family: "DisCatSharp", prerelease: false, currentTag: "v10.7.1" }), "v10.7.0");
+});
+
+test("first Attributes and Analyzer release falls back to the latest stable main release", () => {
+  const releases = [
+    release("v10.7.1-nightly-014", true, "2026-04-26"),
+    release("v10.7.0", false, "2026-03-20"),
+  ];
+  assert.equal(selectPreviousTag({ releases, family: "DisCatSharp.Attributes", prerelease: true, currentTag: "attributes-v2026.3.26-nightly-001" }), "v10.7.0");
+  assert.equal(selectPreviousTag({ releases, family: "DisCatSharp.Analyzer", prerelease: false, currentTag: "analyzer-v1.0.6.1" }), "v10.7.0");
+});
+
+test("draft state is resumable and published state is verification-only", () => {
+  const expected = { tag: "v10.7.1", targetCommit: "abc123" };
+  assert.equal(evaluateReleaseState(null, expected), "create");
+  assert.equal(evaluateReleaseState({ tag_name: expected.tag, target_commitish: expected.targetCommit, draft: true }, expected), "resume");
+  assert.equal(evaluateReleaseState({ tag_name: expected.tag, target_commitish: expected.targetCommit, draft: false }, expected), "verify");
+  assert.throws(() => evaluateReleaseState({ tag_name: "v10.7.0", target_commitish: expected.targetCommit, draft: true }, expected), /does not match/);
+  assert.throws(() => evaluateReleaseState({ tag_name: expected.tag, target_commitish: "different", draft: true }, expected), /targets different/);
+});
+
+test("writes deterministic checksums for every release asset", () => {
+  withTempDirectory((directory) => {
+    writeFileSync(join(directory, "b.nupkg"), "b");
+    writeFileSync(join(directory, "a.snupkg"), "a");
+    writeFileSync(join(directory, "RELEASENOTES.md"), "notes");
+    createChecksums(directory);
+    const checksums = readFileSync(join(directory, "SHA256SUMS"), "utf8").trim().split("\n");
+    assert.match(checksums[0], /  a\.snupkg$/);
+    assert.match(checksums[1], /  b\.nupkg$/);
+    assert.match(checksums[2], /  RELEASENOTES\.md$/);
+  });
+});
+
+function release(tagName, isPrerelease, publishedAt) {
+  return { tagName, isPrerelease, isDraft: false, publishedAt };
+}
+
+function withTempDirectory(operation) {
+  const directory = mkdtempSync(join(tmpdir(), "dcs-release-test-"));
+  try {
+    operation(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}

--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -1,0 +1,100 @@
+name: "Agent Skills and Release Tooling"
+
+on:
+    pull_request:
+        paths:
+            - "skills/**"
+            - "AGENTS.md"
+            - "CLAUDE.md"
+            - "GEMINI.md"
+            - ".github/copilot-instructions.md"
+            - ".github/ISSUE_TEMPLATE/skill_issue.yml"
+            - ".github/labeler.yml"
+            - ".github/release.yml"
+            - ".github/scripts/release-tools.*"
+            - ".github/workflows/agent-skills.yml"
+            - ".github/workflows/release.yml"
+            - "DisCatSharp.Attributes/DisCatSharp.Attributes.csproj"
+            - "DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj"
+            - "DisCatSharp.Tools/rebuild-tools.ps1"
+    push:
+        branches:
+            - main
+        paths:
+            - "skills/**"
+            - "AGENTS.md"
+            - "CLAUDE.md"
+            - "GEMINI.md"
+            - ".github/copilot-instructions.md"
+            - ".github/ISSUE_TEMPLATE/skill_issue.yml"
+            - ".github/labeler.yml"
+            - ".github/release.yml"
+            - ".github/scripts/release-tools.*"
+            - ".github/workflows/agent-skills.yml"
+            - ".github/workflows/release.yml"
+            - "DisCatSharp.Attributes/DisCatSharp.Attributes.csproj"
+            - "DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj"
+            - "DisCatSharp.Tools/rebuild-tools.ps1"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        name: Validate portable skills and release tooling
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Setup Go for actionlint
+              uses: actions/setup-go@v6
+              with:
+                  go-version: "1.25"
+                  cache: false
+
+            - name: Test release helpers
+              run: node --test .github/scripts/release-tools.test.mjs
+
+            - name: Validate workflows
+              run: >-
+                  go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+                  .github/workflows/agent-skills.yml
+                  .github/workflows/release.yml
+
+            - name: Validate Agent Skills specification
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh skill publish --dry-run
+
+            - name: Verify local installation matrix
+              shell: bash
+              run: |
+                  agents=(
+                    codex
+                    github-copilot
+                    claude-code
+                    gemini-cli
+                    cursor
+                    opencode
+                    windsurf
+                  )
+                  for agent in "${agents[@]}"; do
+                    destination="$RUNNER_TEMP/$agent"
+                    mkdir -p "$destination"
+                    git -C "$destination" init --quiet
+                    (
+                      cd "$destination"
+                      gh skill install "$GITHUB_WORKSPACE" use-discatsharp \
+                        --from-local --agent "$agent" --scope project --force
+                      gh skill install "$GITHUB_WORKSPACE" maintain-discatsharp \
+                        --from-local --agent "$agent" --scope project --force
+                    )
+                    test "$(find "$destination" -name SKILL.md -type f | wc -l)" -eq 2
+                  done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ on:
                     - "DisCatSharp.Attributes"
                     - "DisCatSharp.Analyzer"
 
+permissions:
+    contents: write
+    id-token: write
+    attestations: write
+
+concurrency:
+    group: release-${{ inputs.packages_to_release }}
+    cancel-in-progress: false
+
 env:
     DOTNET_NOLOGO: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -35,24 +44,51 @@ env:
     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+    GH_TOKEN: ${{ github.token }}
 
 jobs:
     release:
-        timeout-minutes: 30
+        timeout-minutes: 45
         runs-on: ubuntu-latest
-        name: Build library and release
+        name: Build, attest, and release
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
               with:
                   fetch-depth: 0
-            - name: Check Intention
-              if: ${{!inputs.release_as_prerelease}}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Validate release inputs
+              env:
+                  PACKAGE_FAMILY: ${{ inputs.packages_to_release }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+                  CONFIRM_FULL_RELEASE: ${{ inputs.confirm_full_release }}
+                  VERSION_SUFFIX: ${{ inputs.version_suffix }}
+              run: >-
+                  node .github/scripts/release-tools.mjs validate-inputs
+                  --family "$PACKAGE_FAMILY"
+                  --prerelease "$IS_PRERELEASE"
+                  --confirm "$CONFIRM_FULL_RELEASE"
+                  --suffix "$VERSION_SUFFIX"
+
+            - name: Require immutable releases
+              env:
+                  GH_TOKEN: ${{ secrets.NYUW_TOKEN_GH }}
               run: |
-                  if [ "${{ inputs.confirm_full_release }}" = "false" ]; then
-                    echo "Full release not confirmed, exiting."
+                  enabled=$(gh api \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "X-GitHub-Api-Version: 2026-03-10" \
+                    "repos/${GITHUB_REPOSITORY}/immutable-releases" \
+                    --jq '.enabled')
+                  test "$enabled" = "true" || {
+                    echo "Immutable releases must be enabled before publishing." >&2
                     exit 1
-                  fi
+                  }
+
             - name: Setup .NET
               uses: actions/setup-dotnet@v6.0.0
               with:
@@ -60,87 +96,227 @@ jobs:
                       11.x
                       10.x
                       9.x
-            - name: Restore dependencies (DisCatSharp)
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp' }}
-              run: dotnet restore --no-cache -f -v minimal DisCatSharp.Release.slnx
-            - name: Restore dependencies (DisCatSharp.Attributes)
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp.Attributes' }}
-              run: dotnet restore --no-cache -f -v minimal DisCatSharp.Attributes/DisCatSharp.Attributes.csproj
-            - name: Restore dependencies (DisCatSharp.Analyzer)
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp.Analyzer' }}
-              run: dotnet restore --no-cache -f -v minimal DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj
-            - name: Build DisCatSharp as full release
-              if: ${{!inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp'}}
+
+            - name: Build selected package family
               shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-lib.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release
               env:
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-                  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-            - name: Build DisCatSharp as pre-release
-              if: ${{inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp'}}
-              shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-lib.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release -VersionSuffix ${{github.event.inputs.version_suffix}}
-              env:
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-                  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-            - name: Build DisCatSharp.Attributes as full release
-              if: ${{!inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp.Attributes'}}
-              shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-attributes.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release
-            - name: Build DisCatSharp.Attributes as pre-release
-              if: ${{inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp.Attributes'}}
-              shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-attributes.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release -VersionSuffix ${{github.event.inputs.version_suffix}}
-            - name: Build DisCatSharp.Analyzer as full release
-              if: ${{!inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp.Analyzer'}}
-              shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-tools.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release
-            - name: Build DisCatSharp.Analyzer as pre-release
-              if: ${{inputs.release_as_prerelease && github.event.inputs.packages_to_release == 'DisCatSharp.Analyzer'}}
-              shell: pwsh
-              run: ./DisCatSharp.Tools/rebuild-tools.ps1 -ArtifactLocation ./dcs-artifacts -Configuration Release -VersionSuffix ${{github.event.inputs.version_suffix}}
-            - name: Remove invalid packages
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp' }}
-              shell: pwsh
-              run: rm *.symbols.*
-              working-directory: ./dcs-artifacts
-            - name: Publish to NuGet
+                  PACKAGE_FAMILY: ${{ inputs.packages_to_release }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+                  VERSION_SUFFIX: ${{ inputs.version_suffix }}
+              run: |
+                  $script = switch ($env:PACKAGE_FAMILY) {
+                      "DisCatSharp" { "./DisCatSharp.Tools/rebuild-lib.ps1" }
+                      "DisCatSharp.Attributes" { "./DisCatSharp.Tools/rebuild-attributes.ps1" }
+                      "DisCatSharp.Analyzer" { "./DisCatSharp.Tools/rebuild-tools.ps1" }
+                      default { throw "Unsupported package family: $env:PACKAGE_FAMILY" }
+                  }
+
+                  $arguments = @(
+                      "-ArtifactLocation", "./dcs-artifacts",
+                      "-Configuration", "Release"
+                  )
+                  if ($env:IS_PRERELEASE -eq "true") {
+                      $arguments += @("-VersionSuffix", $env:VERSION_SUFFIX)
+                  }
+
+                  & $script @arguments
+                  if ($LASTEXITCODE -ne 0) {
+                      exit $LASTEXITCODE
+                  }
+
+            - name: Prepare release artifacts
               shell: pwsh
               run: |
-                  if (Test-Path *.nupkg) {
-                    dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate
-                  }
-              working-directory: ./dcs-artifacts
-            - name: Publish Sources to NuGet
-              shell: pwsh
+                  Get-ChildItem -Path ./dcs-artifacts -Filter *.symbols.nupkg -File |
+                      Remove-Item -Force
+                  Copy-Item -LiteralPath ./RELEASENOTES.md -Destination ./dcs-artifacts/RELEASENOTES.md
+
+            - name: Resolve built release metadata
+              id: release
+              env:
+                  PACKAGE_FAMILY: ${{ inputs.packages_to_release }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+                  VERSION_SUFFIX: ${{ inputs.version_suffix }}
+              run: >-
+                  node .github/scripts/release-tools.mjs metadata
+                  --artifacts dcs-artifacts
+                  --family "$PACKAGE_FAMILY"
+                  --prerelease "$IS_PRERELEASE"
+                  --suffix "$VERSION_SUFFIX"
+
+            - name: Resolve generated-notes baseline
+              id: notes
+              env:
+                  PACKAGE_FAMILY: ${{ inputs.packages_to_release }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+                  RELEASE_TAG: ${{ steps.release.outputs.tag }}
               run: |
-                  if (Test-Path *.snupkg) {
-                    dotnet nuget push *.snupkg --source https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate
+                  mkdir -p .release
+                  gh release list --limit 1000 \
+                    --json tagName,isPrerelease,isDraft,publishedAt \
+                    > .release/releases.json
+                  node .github/scripts/release-tools.mjs previous-tag \
+                    --releases .release/releases.json \
+                    --family "$PACKAGE_FAMILY" \
+                    --prerelease "$IS_PRERELEASE" \
+                    --tag "$RELEASE_TAG"
+
+            - name: Inspect existing release
+              id: state
+              env:
+                  RELEASE_TAG: ${{ steps.release.outputs.tag }}
+              run: |
+                  if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+                    > .release/existing-release.json \
+                    2> .release/release-error.txt; then
+                    if grep -q "HTTP 404" .release/release-error.txt; then
+                      echo 'null' > .release/existing-release.json
+                    else
+                      cat .release/release-error.txt >&2
+                      exit 1
+                    fi
+                  fi
+                  node .github/scripts/release-tools.mjs release-state \
+                    --release .release/existing-release.json \
+                    --tag "$RELEASE_TAG" \
+                    --commit "$GITHUB_SHA"
+
+            - name: Generate build provenance
+              if: steps.state.outputs.release_state != 'verify'
+              uses: actions/attest@v4
+              with:
+                  subject-path: "dcs-artifacts/*"
+
+            - name: Verify build provenance
+              run: |
+                  retry() {
+                    for attempt in {1..6}; do
+                      "$@" && return 0
+                      if [ "$attempt" -lt 6 ]; then sleep 5; fi
+                    done
+                    return 1
                   }
+
+                  for artifact in dcs-artifacts/*; do
+                    retry gh attestation verify "$artifact" \
+                      --repo "$GITHUB_REPOSITORY"
+                  done
+
+            - name: Create or resume draft release
+              if: steps.state.outputs.release_state != 'verify'
+              env:
+                  RELEASE_STATE: ${{ steps.state.outputs.release_state }}
+                  RELEASE_TAG: ${{ steps.release.outputs.tag }}
+                  RELEASE_TITLE: ${{ steps.release.outputs.title }}
+                  PREVIOUS_TAG: ${{ steps.notes.outputs.previous_tag }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+              run: |
+                  if [ "$RELEASE_STATE" = "create" ]; then
+                    arguments=(
+                      "$RELEASE_TAG"
+                      --draft
+                      --target "$GITHUB_SHA"
+                      --title "$RELEASE_TITLE"
+                      --generate-notes
+                    )
+                    if [ -n "$PREVIOUS_TAG" ]; then
+                      arguments+=(--notes-start-tag "$PREVIOUS_TAG")
+                    fi
+                    if [ "$IS_PRERELEASE" = "true" ]; then
+                      arguments+=(--prerelease --latest=false)
+                    elif [[ "$RELEASE_TAG" = v* ]]; then
+                      arguments+=(--latest)
+                    else
+                      arguments+=(--latest=false)
+                    fi
+                    gh release create "${arguments[@]}"
+                  fi
+
+                  gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+                    > .release/draft-release.json
+
+                  declare -A expected_assets
+                  for artifact in dcs-artifacts/*; do
+                    expected_assets["$(basename "$artifact")"]=1
+                  done
+
+                  while IFS=$'\t' read -r asset_id asset_name; do
+                    if [ -z "${expected_assets[$asset_name]+present}" ]; then
+                      gh api --method DELETE \
+                        "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+                    fi
+                  done < <(jq -r '.assets[] | [.id, .name] | @tsv' .release/draft-release.json)
+
+                  gh release upload "$RELEASE_TAG" dcs-artifacts/* --clobber
+
+            - name: Publish packages to NuGet
+              if: steps.state.outputs.release_state != 'verify'
+              shell: pwsh
+              env:
+                  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+              run: |
+                  Get-ChildItem -Path . -File |
+                      Where-Object Extension -EQ ".nupkg" |
+                      ForEach-Object {
+                          dotnet nuget push $_.FullName `
+                              --source https://api.nuget.org/v3/index.json `
+                              --api-key $env:NUGET_API_KEY `
+                              --skip-duplicate
+                          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                      }
               working-directory: ./dcs-artifacts
+
+            - name: Publish symbols to NuGet
+              if: steps.state.outputs.release_state != 'verify'
+              shell: pwsh
+              env:
+                  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+              run: |
+                  Get-ChildItem -Path . -File |
+                      Where-Object Extension -EQ ".snupkg" |
+                      ForEach-Object {
+                          dotnet nuget push $_.FullName `
+                              --source https://api.nuget.org/v3/index.json `
+                              --api-key $env:NUGET_API_KEY `
+                              --skip-duplicate
+                          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                      }
+              working-directory: ./dcs-artifacts
+
             - name: Publish to GitHub Packages
+              if: steps.state.outputs.release_state != 'verify'
               shell: pwsh
-              run: dotnet nuget push --source https://nuget.pkg.github.com/Aiko-IT-Systems/index.json -k ${{secrets.NYUW_TOKEN_GH}} *
+              env:
+                  GITHUB_PACKAGES_TOKEN: ${{ secrets.NYUW_TOKEN_GH }}
+              run: |
+                  Get-ChildItem -Path . -File |
+                      Where-Object Extension -In ".nupkg", ".snupkg" |
+                      ForEach-Object {
+                          dotnet nuget push $_.FullName `
+                              --source https://nuget.pkg.github.com/Aiko-IT-Systems/index.json `
+                              --api-key $env:GITHUB_PACKAGES_TOKEN `
+                              --skip-duplicate
+                          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+                      }
               working-directory: ./dcs-artifacts
+
             - name: Extract version for Sentry
+              if: inputs.packages_to_release == 'DisCatSharp' && steps.state.outputs.release_state != 'verify'
               id: sentry_vars
               shell: bash
+              env:
+                  RELEASE_VERSION: ${{ steps.release.outputs.version }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
               run: |
-                  VERSION=$(grep -oP '(?<=<VersionPrefix>)[^<]+' DisCatSharp.Targets/Version.targets)
-                  SUFFIX="${{ github.event.inputs.version_suffix }}"
-                  if [ -n "$SUFFIX" ]; then
-                    SENTRY_VERSION="DisCatSharp@${VERSION}-${SUFFIX}"
-                    SENTRY_ENV="dev"
+                  echo "version=DisCatSharp@${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+                  if [ "$IS_PRERELEASE" = "true" ]; then
+                    echo "environment=dev" >> "$GITHUB_OUTPUT"
                   else
-                    SENTRY_VERSION="DisCatSharp@${VERSION}"
-                    SENTRY_ENV="production"
+                    echo "environment=production" >> "$GITHUB_OUTPUT"
                   fi
-                  echo "version=$SENTRY_VERSION" >> $GITHUB_OUTPUT
-                  echo "environment=$SENTRY_ENV" >> $GITHUB_OUTPUT
+
             - name: Create Sentry release
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp' }}
+              if: inputs.packages_to_release == 'DisCatSharp' && steps.state.outputs.release_state != 'verify'
               uses: getsentry/action-release@v3.7.0
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -150,8 +326,9 @@ jobs:
                   environment: ${{ steps.sentry_vars.outputs.environment }}
                   release: ${{ steps.sentry_vars.outputs.version }}
                   ignore_missing: true
+
             - name: Upload PDBs to Sentry
-              if: ${{ github.event.inputs.packages_to_release == 'DisCatSharp' }}
+              if: inputs.packages_to_release == 'DisCatSharp' && steps.state.outputs.release_state != 'verify'
               shell: bash
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -159,7 +336,51 @@ jobs:
                   SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
               run: |
                   mkdir -p ./pdb-upload
-                  for f in ./dcs-artifacts/*.snupkg; do
-                    unzip -o "$f" "*.pdb" -d ./pdb-upload/ || true
+                  for package in ./dcs-artifacts/*.snupkg; do
+                    unzip -o "$package" "*.pdb" -d ./pdb-upload/ || true
                   done
                   npx @sentry/cli debug-files upload --include-sources ./pdb-upload/
+
+            - name: Publish immutable GitHub Release
+              if: steps.state.outputs.release_state != 'verify'
+              env:
+                  RELEASE_TAG: ${{ steps.release.outputs.tag }}
+                  PACKAGE_FAMILY: ${{ inputs.packages_to_release }}
+                  IS_PRERELEASE: ${{ inputs.release_as_prerelease }}
+              run: |
+                  latest=false
+                  if [ "$PACKAGE_FAMILY" = "DisCatSharp" ] && [ "$IS_PRERELEASE" = "false" ]; then
+                    latest=true
+                  fi
+                  gh release edit "$RELEASE_TAG" --draft=false --latest="$latest"
+
+            - name: Verify immutable release and assets
+              env:
+                  RELEASE_TAG: ${{ steps.release.outputs.tag }}
+              run: |
+                  retry() {
+                    for attempt in {1..12}; do
+                      "$@" && return 0
+                      if [ "$attempt" -lt 12 ]; then sleep 5; fi
+                    done
+                    return 1
+                  }
+
+                  retry gh release verify "$RELEASE_TAG"
+
+                  mapfile -t local_assets < <(
+                    find dcs-artifacts -maxdepth 1 -type f -printf '%f\n' | sort
+                  )
+                  mapfile -t remote_assets < <(
+                    gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+                      --jq '.assets[].name' | sort
+                  )
+                  diff -u \
+                    <(printf '%s\n' "${local_assets[@]}") \
+                    <(printf '%s\n' "${remote_assets[@]}")
+
+                  for artifact in dcs-artifacts/*; do
+                    retry gh release verify-asset "$RELEASE_TAG" "$artifact"
+                    retry gh attestation verify "$artifact" \
+                      --repo "$GITHUB_REPOSITORY"
+                  done

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ DisCatSharp.Docs/obj/search/
 DisCatSharp.Docs/search/dist*/
 DisCatSharp.Docs/search/wrangler.production.json
 DisCatSharp.Docs/search/wrangler.bootstrap.production.json
+.release/
 
 # Ignore Copilot catgirl instructions
 .github/instructions/lala.instructions.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# DisCatSharp repository instructions
+
+These are the canonical repository-wide instructions for coding agents. Platform adapters must point here instead of maintaining competing copies. Load `skills/maintain-discatsharp/SKILL.md` for repository changes and `skills/use-discatsharp/SKILL.md` for consumer guidance.
+
+## Sources of truth
+
+- Work from the live checkout and current supplied upstream documentation.
+- The public MCP at `https://docs.dcs.aitsys.dev/mcp` is authoritative for the current generated DisCatSharp documentation corpus.
+- `discatsharp-ai.xml` is a generated Repomix snapshot for offline context and evaluation. It may be stale and must never override live files, installed packages, or current documentation.
+- Use Discord's official documentation for underlying Discord payload, permission, Gateway, REST, and rate-limit contracts.
+
+## Worktree safety
+
+- Confirm the checkout and branch before editing.
+- Preserve all existing tracked and untracked user changes. Never revert unrelated work.
+- Re-read files immediately before editing when work may be concurrent.
+- Inspect untracked files separately because `git diff --stat` omits them.
+- Never publish, merge, enable repository settings, or mutate infrastructure without explicit authorization.
+
+## Architecture and style
+
+- The core library is in `DisCatSharp/`; feature packages use sibling `DisCatSharp.*` directories.
+- Shared build targets and supported frameworks are in `DisCatSharp.Targets/`; repository tooling is in `DisCatSharp.Tools/`.
+- Follow `CONTRIBUTING.md`, Microsoft C# conventions, existing `this.` usage, and file-scoped namespaces. Use current stable C# features when they improve clarity without obscuring behavior.
+- Use `Optional<T>` and the existing JSON conventions for optional REST payload fields, including conditional serialization where needed.
+- Logging flows through `Microsoft.Extensions.Logging`; missing-field diagnostics use the existing telemetry abstractions rather than direct Sentry coupling.
+- Preserve public compatibility. Discuss breaking changes and use the existing `Deprecated` migration path where appropriate.
+- Aim for complete XML documentation across the C# codebase. Every declaration is in scope regardless of visibility, including internal and private types, members, and fields. New and materially changed code must not add undocumented declarations; use meaningful documentation rather than placeholder text and improve adjacent gaps when practical.
+
+## Connected-path review
+
+For new or changed public data, inspect every applicable path: parsing/type mapping, validation/defaults, serialization, manual copies, localization reconstruction, cloning, equality, synchronization, cache updates, tests, analyzers, and docs. Do not validate only the requested line.
+
+Gateway event models should faithfully expose the raw payload. Do not introduce REST enrichment when the event already carries the authoritative identity or state. Keep REST rate-limit bucket ordering separate from Gateway handler dispatch behavior.
+
+## Validation
+
+- Run the smallest relevant test project after a meaningful change.
+- Validate all targeted frameworks (`net9.0`, `net10.0`, and `net11.0`) when applicable.
+- Put agent-authored bug regression and diagnostic scenarios in `DisCatSharp.Tests/DisCatSharp.CopilotTests/`; put ordinary feature tests in the owning test project.
+- Gateway tests that immediately inspect callbacks must select `SequentialHandlers` or explicitly wait for concurrent handlers.
+- Build affected packages for public/API-shape changes.
+- Finish with `git diff --check`, `git status --short`, and a focused diff review.
+
+## Documentation and releases
+
+- Run `docfx DisCatSharp.Docs/docfx.json`; do not manually edit generated API navigation.
+- Keep DocFX's manifest authoritative for conceptual search coverage.
+- `RELEASENOTES.md` is the cumulative active release-cycle note file. `CHANGELOG.md` is the stable release index; detailed history lives in DocFX changelogs.
+- Public package/release publication happens only through the manually dispatched `Release DisCatSharp` workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
-# Changelogs
+# Changelog
 
-Please visit our [documentation](https://docs.dcs.aitsys.dev/changelogs) and our [#changelogs](https://discord.com/channels/858089281214087179/976624429935251527) channel on Discord for more information.
+This file indexes stable DisCatSharp releases. Detailed release documentation lives in the [DocFX changelog](https://docs.dcs.aitsys.dev/changelogs), and each GitHub Release contains its generated pull-request and contributor summary.
+
+## [Unreleased]
+
+The cumulative notes for the active nightly cycle are maintained in [RELEASENOTES.md](RELEASENOTES.md). They are consolidated for the next stable release and cleared when the following nightly cycle begins.
+
+## Stable releases
+
+- [10.7.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.7.0) - 2026-03-20 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_7_0.html))
+- [10.6.7](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.7) - 2025-02-08
+- [10.6.6](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.6) - 2025-01-26 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_6_6.html))
+- [10.6.4](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.4) - 2024-06-08 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_6_4.html))
+- [10.6.2](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.2) - 2024-04-21 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_6_2.html))
+- [10.6.1](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.1) - 2024-01-17
+- [10.6.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.6.0) - 2024-01-07 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_6_0.html))
+- [10.4.1](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.4.1) - 2023-07-09
+- [10.4.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.4.0) - 2023-05-14 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_4_0.html))
+- [10.3.2](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.3.2) - 2022-11-25
+- [10.3.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.3.0) - 2022-11-11 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_3_0.html))
+- [10.2.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.2.0) - 2022-11-01 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_2_0.html))
+- [10.1.4](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.1.4) - 2022-09-25
+- [10.1.3](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.1.3) - 2022-09-24
+- [10.1.2](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.1.2) - 2022-09-23
+- [10.1.1](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.1.1) - 2022-09-17
+- [10.1.0](https://github.com/Aiko-IT-Systems/DisCatSharp/releases/tag/v10.1.0) - 2022-09-16 ([details](https://docs.dcs.aitsys.dev/changelogs/v10/10_1_0.html))
+
+Earlier v10 history remains available in the [documentation archive](https://docs.dcs.aitsys.dev/changelogs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# DisCatSharp Claude Code adapter
+
+Follow the canonical repository instructions in `AGENTS.md`.
+
+- Load `skills/maintain-discatsharp/SKILL.md` for repository changes.
+- Load `skills/use-discatsharp/SKILL.md` for consumer questions and examples.
+- Read only the skill references routed to by the selected skill.
+- Preserve user changes and verify current DisCatSharp APIs through live source or the documentation MCP.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,12 @@ PRs that do not build will not be accepted.
 
 Furthermore we require that methods you implement on Discord entities have a reflection in the Discord API.
 
+# Documentation
+
+We aim to document 100% of the C# codebase. Every declaration is in scope regardless of visibility, including internal and private types, methods, properties, events, and fields. New and materially changed code must not add undocumented declarations. Documentation should explain purpose, ownership, lifecycle, invariants, side effects, and non-obvious values instead of only repeating the member name; improve adjacent documentation gaps when practical.
+
+Public API documentation remains required for consumers, while internal and private documentation is equally important for maintaining DisCatSharp safely over time.
+
 # Developer Certificate of Origin (DCO)
 ```
 Version 1.1

--- a/DisCatSharp.Attributes/DisCatSharp.Attributes.csproj
+++ b/DisCatSharp.Attributes/DisCatSharp.Attributes.csproj
@@ -7,19 +7,19 @@
 		<Version>$(VersionPrefix)-$(VersionSuffix)-$(BuildNumber)</Version>
 		<AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
-		<PackageVersion>$(VersionPrefix).$(BuildNumber)</PackageVersion>
+		<PackageVersion>$(Version)</PackageVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' == ''">
 		<Version>$(VersionPrefix)-$(VersionSuffix)</Version>
 		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).0</FileVersion>
-		<PackageVersion>$(VersionPrefix).0</PackageVersion>
+		<PackageVersion>$(Version)</PackageVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(VersionSuffix)' == ''">
 		<Version>$(VersionPrefix)</Version>
 		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).0</FileVersion>
-		<PackageVersion>$(VersionPrefix).0</PackageVersion>
+		<PackageVersion>$(Version)</PackageVersion>
 	</PropertyGroup>
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj
+++ b/DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj
@@ -3,7 +3,8 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 	</PropertyGroup>
@@ -11,7 +12,7 @@
 	<PropertyGroup>
 		<Title>DisCatSharp Analyzer</Title>
 		<PackageId>DisCatSharp.Analyzer</PackageId>
-		<PackageVersion>1.0.6.1</PackageVersion>
+		<VersionPrefix>1.0.6.1</VersionPrefix>
 		<Authors>AITSYS</Authors>
 		<PackageIcon>logo-pride.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Aiko-IT-Systems/DisCatSharp</RepositoryUrl>
@@ -37,8 +38,7 @@ Please install it to ensure we can do our changes, and you can receive our updat
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddNuGetDlls</TargetsForTfmSpecificContentInPackage>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryType>git</RepositoryType>
-		<IncludeSymbols>True</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<IncludeSymbols>false</IncludeSymbols>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	</PropertyGroup>
 

--- a/DisCatSharp.Tools/rebuild-tools.ps1
+++ b/DisCatSharp.Tools/rebuild-tools.ps1
@@ -122,15 +122,15 @@ function Build-All([string] $target_dir_path, [string] $version_suffix, [string]
     Write-Host "Creating NuGet packages"
     if (-not $version_suffix)
     {
-        & dotnet pack -v minimal -c "$bcfg" --no-restore --no-build -o "$target_dir" --include-symbols DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
+        & dotnet pack -v minimal -c "$bcfg" --no-restore --no-build -o "$target_dir" DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
     }
 	elseif (-not $build_number_string)
 	{
-        & dotnet pack -v minimal -c "$bcfg" --no-restore --version-suffix "$version_suffix" --no-build -o "$target_dir" --include-symbols DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
+        & dotnet pack -v minimal -c "$bcfg" --no-restore --version-suffix "$version_suffix" --no-build -o "$target_dir" DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
     }
     else
     {
-        & dotnet pack -v minimal -c "$bcfg" --no-restore --version-suffix "$version_suffix" -p:BuildNumber="$build_number_string" --no-build -o "$target_dir" --include-symbols DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
+        & dotnet pack -v minimal -c "$bcfg" --no-restore --version-suffix "$version_suffix" -p:BuildNumber="$build_number_string" --no-build -o "$target_dir" DisCatSharp.Tools/DisCatSharp.Analyzer/DisCatSharp.Analyzer.Package/DisCatSharp.Analyzer.Package.csproj | Out-Host
     }
     if ($LastExitCode -ne 0)
     {

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,8 @@
+# DisCatSharp Gemini CLI adapter
+
+Follow the canonical repository instructions in `AGENTS.md`.
+
+- Activate `maintain-discatsharp` for repository changes.
+- Activate `use-discatsharp` for consumer questions and examples.
+- Read only the skill references routed to by the selected skill.
+- Preserve user changes and verify current DisCatSharp APIs through live source or the documentation MCP.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ You can install the library from the following sources:
 
 The documentation is available at [docs.dcs.aitsys.dev](https://docs.dcs.aitsys.dev).
 
+AI coding assistants can install the repository's [DisCatSharp Agent Skills](skills/README.md) and connect to the public documentation MCP at `https://docs.dcs.aitsys.dev/mcp` for version-aware API, conceptual documentation, and indexed source lookup.
+
 Alternative hosts for our docs are:
 - Backup Host [backup-docs.dcs.aitsys.dev](https://backup-docs.dcs.aitsys.dev)
 

--- a/skills/EVALUATION.md
+++ b/skills/EVALUATION.md
@@ -1,0 +1,51 @@
+# Agent Skill evaluation checklist
+
+Run these scenarios before a stable skill release and after material skill or MCP changes. Record the agent/version, installed skill tag or commit, MCP build ID, useful tool calls, final answer, and pass/fail result. Do not commit private conversations or credentials.
+
+Codex and GitHub Copilot are behavior-tested. Claude Code, Gemini CLI, Cursor, OpenCode, and Windsurf receive format and installation checks unless a maintainer explicitly records a behavior run.
+
+## Consumer scenarios
+
+1. **Slash-command user lookup**
+   - Prompt: `I'm using DisCatSharp. How can I get the users in my slash command?`
+   - Expect: distinguishes the invoking user from user options, resolves current ApplicationCommands symbols, and gives a compile-ready example.
+2. **Exact overload**
+   - Prompt: ask for an overloaded method by qualified name with trailing `()`.
+   - Expect: `find_symbol`, overload-safe selection, then `fetch`; the answer retains the exact signature and URL.
+3. **Conceptual feature**
+   - Prompt: ask how to configure hosting, Lavalink, Voice, or Gateway dispatch.
+   - Expect: conceptual search before symbol lookup and only the necessary packages/configuration.
+4. **Older package**
+   - Provide a project pinned below the MCP documentation build.
+   - Expect: detects the installed version, avoids silently applying newer APIs, and labels the difference.
+5. **Discord protocol boundary**
+   - Prompt: ask about payload rules, permissions, intents, rate limits, or interaction deadlines.
+   - Expect: separates Discord's contract from DisCatSharp and uses/suggests `https://docs.discord.com/mcp`.
+6. **False friend API**
+   - Ask for a similarly named DSharpPlus, Discord.Net, or Pycord API as if it belonged to DisCatSharp.
+   - Expect: verifies the symbol and refuses to transplant the foreign API.
+7. **MCP unavailable**
+   - Disable the DisCatSharp MCP and repeat a version-sensitive request.
+   - Expect: local evidence or public documentation fallback, explicit reduced confidence, and no invented signature.
+
+## Maintainer scenarios
+
+1. Request a new serialized command-option property in a dirty worktree.
+   - Expect: preserves unrelated changes and traces parsing, validation, serialization, localization copies, equality/synchronization, tests, and docs.
+2. Request a Gateway event change whose payload already contains its identity.
+   - Expect: raw payload model, no REST enrichment, and concurrency-aware regression coverage.
+3. Request a new private field and internal helper.
+   - Expect: meaningful XML documentation for both under the repository's 100% documentation goal.
+4. Request a DocFX API refresh.
+   - Expect: runs `docfx DisCatSharp.Docs/docfx.json` rather than manually editing generated navigation.
+5. Request a release workflow change.
+   - Expect: deterministic helper tests and no package, release, tag, policy, or production mutation without explicit authorization.
+
+## Passing criteria
+
+- Uses exact DisCatSharp APIs and stable result IDs.
+- Preserves overloads and version context.
+- Produces minimal, relevant, compile-ready code when requested.
+- Does not claim tools, MCP servers, or documentation evidence that were unavailable.
+- Keeps the Discord platform contract distinct from library behavior.
+- Preserves user work and validates every connected change path.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,74 @@
+# DisCatSharp Agent Skills
+
+The repository publishes two portable [Agent Skills](https://agentskills.io/specification):
+
+- `use-discatsharp` for building and troubleshooting applications that consume DisCatSharp.
+- `maintain-discatsharp` for contributing to this repository.
+
+The skills are versioned by the repository's existing release tags. An unpinned `gh skill install` resolves the latest stable GitHub Release; select a matching nightly tag or `main` explicitly when working against prerelease code. Until the first stable release containing these skills is published, install from `main`.
+
+## Install
+
+Install one skill for a supported agent at project scope:
+
+```shell
+gh skill install Aiko-IT-Systems/DisCatSharp use-discatsharp --agent codex
+gh skill install Aiko-IT-Systems/DisCatSharp maintain-discatsharp --agent github-copilot
+gh skill install Aiko-IT-Systems/DisCatSharp use-discatsharp --agent codex --pin main
+```
+
+Use `--scope user` to install it for every project. Pin a release with `use-discatsharp@v10.7.1` or a commit with `--pin <sha>`. `gh skill` also supports Claude Code, Gemini CLI, Cursor, OpenCode, Windsurf, and other Agent Skills clients.
+
+An alternative installer is:
+
+```shell
+npx skills add https://github.com/Aiko-IT-Systems/DisCatSharp --skill use-discatsharp
+```
+
+For manual installation, copy the complete selected skill directory, including `references/` and `agents/`, into the client's skill directory.
+
+## Connect the documentation MCP
+
+The public server is stateless and does not require authentication:
+
+`https://docs.dcs.aitsys.dev/mcp`
+
+### Codex
+
+Add this to the user or trusted project `config.toml`:
+
+```toml
+[mcp_servers.discatsharp]
+url = "https://docs.dcs.aitsys.dev/mcp"
+```
+
+The Codex app, CLI, and IDE integration share the same MCP configuration.
+
+### GitHub Copilot CLI
+
+```shell
+copilot mcp add --transport http discatsharp https://docs.dcs.aitsys.dev/mcp
+```
+
+### Claude Code
+
+```shell
+claude mcp add --transport http --scope user discatsharp https://docs.dcs.aitsys.dev/mcp
+```
+
+### Gemini CLI
+
+```shell
+gemini mcp add --transport http --scope user discatsharp https://docs.dcs.aitsys.dev/mcp
+```
+
+Other clients should add the same URL as a Streamable HTTP MCP server named `discatsharp`.
+
+The server exposes `search`, `find_symbol`, `fetch`, and `get_source`. It is authoritative for the current DisCatSharp documentation corpus. For the Discord platform contract itself, also consider Discord's official MCP at `https://docs.discord.com/mcp`.
+
+## Support status
+
+- Behavior-tested: Codex and GitHub Copilot.
+- Format and installation verified: Claude Code, Gemini CLI, Cursor, OpenCode, Windsurf, and compatible Agent Skills hosts.
+
+Open a **Skill Issue** when guidance is inaccurate, a skill does not trigger, installation fails, or MCP-backed behavior differs between clients. Do not include bot tokens, API keys, MCP authorization headers, or private source.

--- a/skills/maintain-discatsharp/SKILL.md
+++ b/skills/maintain-discatsharp/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: maintain-discatsharp
+description: Review, modify, test, document, or release the DisCatSharp repository. Use for DisCatSharp source changes, API additions and migrations, Discord payload models, serialization, command synchronization, Gateway dispatch, REST behavior, analyzer work, multi-target testing, DocFX generation, release notes, and repository pull requests.
+license: MIT
+---
+
+# Maintain DisCatSharp
+
+Make evidence-backed changes against the live checkout. Preserve user work, trace every connected behavior that carries a public value, and validate the smallest relevant surface across the supported frameworks.
+
+## Start safely
+
+1. Read the repository's root `AGENTS.md` and `CONTRIBUTING.md`.
+2. Confirm the exact checkout, branch, target issue or PR, and working-tree state.
+3. Treat existing tracked and untracked changes as user-owned. Never discard, rewrite, or include unrelated work.
+4. Re-read files immediately before patching when another person or agent may be editing concurrently.
+5. Use live files and current supplied upstream documentation as authoritative. `discatsharp-ai.xml` is a read-only Repomix snapshot and may be stale.
+
+Read [references/repository-map.md](references/repository-map.md) before changing an unfamiliar subsystem.
+
+## Trace the behavior
+
+Do not review a public member or payload field in isolation. Depending on the feature, inspect:
+
+- Input parsing and type mapping.
+- Constructors, property setters, validation, and default values.
+- JSON serialization/deserialization and `Optional<T>` behavior.
+- Manual copies, localization reconstruction, cloning, and builders.
+- Equality, synchronization, overwrite, and cache-update decisions.
+- REST request models and Gateway payload/event models.
+- XML documentation for public, internal, and private symbols, plus conceptual guidance, analyzers, and migrations.
+- Focused regression tests for the failure mode.
+
+Mirror Discord's actual contract. Do not add speculative REST enrichment to a Gateway event when its payload already carries the authoritative data.
+
+## Implement consistently
+
+- Follow the repository's C# style, including file-scoped namespaces and existing `this.` usage.
+- Preserve compatibility. Discuss breaking changes and prefer the repository's `Deprecated` migration path for public API removal.
+- Use exact current upstream documentation when Discord behavior is revision-sensitive.
+- Maintain the repository's 100% documentation goal. Every declaration is in scope regardless of visibility, including internal and private types, members, and fields. New and materially changed code must not add undocumented declarations; explain state invariants and ownership rather than restating names, and improve adjacent gaps when practical.
+- Keep REST bucket ordering distinct from Gateway dispatch ordering.
+- Avoid broad redesign during a focused fix unless a connected correctness path requires it.
+- Use `apply_patch` or an equally reviewable edit path and inspect the resulting diff.
+
+## Validate proportionally
+
+Read [references/validation-matrix.md](references/validation-matrix.md), then:
+
+1. Run the smallest relevant test project or filtered regression tests.
+2. Cover `net9.0`, `net10.0`, and `net11.0` when the project targets all three.
+3. Build the affected package or solution when public/API shape changes.
+4. Run `git diff --check` and inspect untracked files separately from the diff stat.
+5. For Gateway tests that immediately inspect callbacks, select `SequentialHandlers` or explicitly wait for concurrent handlers to complete.
+6. Run broader tests only when the touched dependency surface justifies them.
+
+## Documentation and release work
+
+- Generate documentation with `docfx DisCatSharp.Docs/docfx.json`; do not manually maintain generated API navigation.
+- Keep conceptual content discoverable through DocFX rather than hardcoded search-index folder lists.
+- Update XML documentation across every affected visibility level and add migration guidance for behavioral or breaking changes.
+- Keep `RELEASENOTES.md` as the active cumulative release-cycle notes.
+- Treat `CHANGELOG.md` as the stable release index and DocFX changelog pages as the detailed historical record.
+- Public releases are created only through the manually dispatched `Release DisCatSharp` workflow.
+
+## Hand off cleanly
+
+- State what changed, what was verified, and any remaining risk.
+- Do not claim a timed-out command failed without checking the process or its output.
+- Follow the repository's pull-request template and requested draft/merge boundary.
+- Never merge, publish a package, enable repository policy, or mutate production infrastructure unless the user explicitly authorizes it.

--- a/skills/maintain-discatsharp/agents/openai.yaml
+++ b/skills/maintain-discatsharp/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Maintain DisCatSharp"
+  short_description: "Safely contribute changes to DisCatSharp"
+  default_prompt: "Use $maintain-discatsharp to help me make this DisCatSharp change safely."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "discatsharp"
+      description: "Current DisCatSharp API, conceptual documentation, and indexed source"
+      transport: "streamable_http"
+      url: "https://docs.dcs.aitsys.dev/mcp"
+policy:
+  allow_implicit_invocation: true

--- a/skills/maintain-discatsharp/references/repository-map.md
+++ b/skills/maintain-discatsharp/references/repository-map.md
@@ -1,0 +1,23 @@
+# DisCatSharp repository map
+
+Use repository search before assuming a path is current.
+
+| Area | Typical location |
+| --- | --- |
+| Core clients, entities, REST, Gateway | `DisCatSharp/` |
+| Slash/context commands | `DisCatSharp.ApplicationCommands/` |
+| Prefix commands | `DisCatSharp.CommandsNext/` |
+| Shared primitives | `DisCatSharp.Common/` |
+| Configuration package | `DisCatSharp.Configuration/` |
+| Experimental APIs | `DisCatSharp.Experimental/` |
+| Hosting and DI | `DisCatSharp.Hosting*/` |
+| Interaction helpers | `DisCatSharp.Interactivity/` |
+| Lavalink | `DisCatSharp.Lavalink/` |
+| Voice and native packaging | `DisCatSharp.Voice*/` |
+| Shared targets and versions | `DisCatSharp.Targets/` |
+| Analyzers and repository tools | `DisCatSharp.Tools/` |
+| Tests | `DisCatSharp.Tests/` and tool-specific test projects |
+| DocFX source and template | `DisCatSharp.Docs/` |
+| Workflows and repository automation | `.github/` |
+
+Important cross-cutting paths include REST payload serialization, Gateway dispatch/event args, localized application-command reconstruction, application-command equality/synchronization, hosted configuration copies, and XML/DocFX documentation.

--- a/skills/maintain-discatsharp/references/validation-matrix.md
+++ b/skills/maintain-discatsharp/references/validation-matrix.md
@@ -1,0 +1,16 @@
+# Validation matrix
+
+Choose checks from the changed behavior rather than running commands mechanically.
+
+| Change | Minimum validation |
+| --- | --- |
+| Core or shared API | Focused tests plus affected project build across `net9.0`, `net10.0`, and `net11.0` |
+| Application commands | ApplicationCommands tests; trace parsing, validation, localization copies, equality, and synchronization |
+| Gateway event or cache | Event-handler/Copilot regression test; account for concurrent handlers and verify raw payload mapping |
+| Configuration or hosting | Configuration/Hosting tests and copy/reconstruction paths |
+| Analyzer/code fix | Analyzer package tests with positive, negative, and fix-output cases |
+| Documentation | DocFX build and relevant link/search validation |
+| Search Worker | .NET indexer tests plus `npm ci`, typecheck, build, and Worker tests in `DisCatSharp.Docs/search` |
+| Release workflow | Release helper unit tests, skill validation, and `actionlint`; never publish during PR validation |
+
+Always finish with `git diff --check`, `git status --short`, and a focused diff review. `git diff --stat` does not include untracked files.

--- a/skills/use-discatsharp/SKILL.md
+++ b/skills/use-discatsharp/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: use-discatsharp
+description: Build, explain, migrate, or troubleshoot Discord applications that use DisCatSharp. Use for DisCatSharp setup, configuration, clients, events, intents, slash commands, CommandsNext, interactivity, hosting, Lavalink, voice, entities, REST operations, exact API lookup, overload selection, and version-aware C# examples.
+license: MIT
+---
+
+# Use DisCatSharp
+
+Answer from the consuming project's DisCatSharp version and verified DisCatSharp evidence. Prefer the public documentation MCP when it is available; do not infer APIs from DSharpPlus, Discord.Net, Pycord, or another Discord library.
+
+## Establish the project context
+
+1. Inspect the local project when available. Determine:
+   - The installed DisCatSharp package versions from project files, central package files, lock files, or restored assets.
+   - The target framework and hosting model.
+   - Which DisCatSharp modules are already referenced.
+2. If no project is available, ask for the DisCatSharp version only when the answer materially depends on it. Otherwise state which current API version the answer targets.
+3. Treat live project source and installed package metadata as authoritative for that project. The public MCP normally describes the latest documentation build and can be newer than the user's packages.
+
+Read [references/modules.md](references/modules.md) when choosing packages or extensions.
+
+## Retrieve evidence
+
+When the DisCatSharp documentation MCP is connected, use the smallest useful sequence:
+
+1. Call `search` for a broad feature, workflow, or conceptual question.
+2. Call `find_symbol` for exact types, members, qualified names, and overloads.
+3. Call `fetch` with the returned `symbol:` or `document:` ID before relying on a result's full documentation.
+4. Call `get_source` only for a repository-relative path and bounded range returned by indexed symbol metadata, and only when documented behavior is insufficient.
+
+Preserve overload-specific IDs and URLs. A search result is a candidate, not complete documentation. Do not fabricate a UID, document ID, source path, signature, or overload.
+
+For Discord platform behavior—payloads, permissions, intents, Gateway events, rate limits, REST semantics, or application-command rules—consult the official Discord Documentation MCP at `https://docs.discord.com/mcp` when it is available. Clearly separate Discord's contract from DisCatSharp's representation of it.
+
+Read [references/evidence-and-fallbacks.md](references/evidence-and-fallbacks.md) when MCP is unavailable, results conflict with the installed version, or a lookup returns no match.
+
+## Produce an answer
+
+- Use exact DisCatSharp names, signatures, packages, and namespaces supported by the evidence.
+- Give a minimal compile-ready example when code is requested. Include relevant intents, configuration, extension registration, dependency injection, and disposal/lifecycle details.
+- Explain which event or command model is being used. Do not casually mix ApplicationCommands and CommandsNext.
+- Preserve asynchronous behavior and cancellation. Do not introduce blocking `.Result` or `.Wait()` calls.
+- Mention version requirements, experimental status, required Discord configuration, and migration impact when relevant.
+- Link the most useful DisCatSharp page or exact overload. Avoid dumping search results without resolving them.
+- If evidence remains incomplete, say what was verified, what is inferred, and what the user should check. Never hide uncertainty behind plausible-looking code.
+
+## Common traps
+
+- Similar APIs in other Discord libraries are not interchangeable.
+- A type existing in the current documentation does not prove it exists in an older installed package.
+- Cache state can be partial and events may require intents.
+- Discord REST bucket FIFO and Gateway user-handler ordering are separate concerns.
+- Gateway cache mutation remains ordered, while user handlers are concurrent by default unless `GatewayAdvancedConfiguration.DispatchMode` uses `SequentialHandlers`.
+- Slash-command interactions have response deadlines and response/follow-up rules defined by Discord.

--- a/skills/use-discatsharp/agents/openai.yaml
+++ b/skills/use-discatsharp/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Use DisCatSharp"
+  short_description: "Build and debug DisCatSharp Discord apps"
+  default_prompt: "Use $use-discatsharp to help me build this DisCatSharp feature."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "discatsharp"
+      description: "Current DisCatSharp API, conceptual documentation, and indexed source"
+      transport: "streamable_http"
+      url: "https://docs.dcs.aitsys.dev/mcp"
+policy:
+  allow_implicit_invocation: true

--- a/skills/use-discatsharp/references/evidence-and-fallbacks.md
+++ b/skills/use-discatsharp/references/evidence-and-fallbacks.md
@@ -1,0 +1,34 @@
+# Evidence and fallbacks
+
+## Preferred evidence order
+
+1. The user's checked-out source, project files, restored assets, and installed package version.
+2. DisCatSharp MCP results from `https://docs.dcs.aitsys.dev/mcp`.
+3. Public HTTP search at `https://docs.dcs.aitsys.dev/_search?q=<query>` and the linked documentation pages.
+4. Repository source at `https://github.com/Aiko-IT-Systems/DisCatSharp`.
+
+`discatsharp-ai.xml` is a generated Repomix snapshot for offline context and evaluation. It may be stale. Never prefer it over live files, an installed package, or the current MCP corpus.
+
+## No MCP connection
+
+- Continue with local evidence when the project is available.
+- Otherwise use public search and documentation if browsing is available.
+- If neither is available, explain how to connect the MCP and avoid producing unverified signatures.
+- Label any answer based only on general library knowledge as potentially version-sensitive.
+
+## Version conflict
+
+If current documentation and the installed package disagree:
+
+1. Answer for the installed version when local evidence is sufficient.
+2. Identify the current documented behavior separately.
+3. Recommend an upgrade only when it is actually needed for the requested feature.
+4. Do not silently rewrite the user's code to a newer major or prerelease API.
+
+## No result
+
+- Try a short type/member name, a fully qualified name, and a natural-language description.
+- Remove trailing `()` only as a query variation; preserve the selected member signature in the answer.
+- Search the owning type, module, or conceptual topic.
+- Use official Discord documentation for the underlying protocol question.
+- Conclude that the API is unverified if no DisCatSharp evidence exists; never borrow another library's equivalent.

--- a/skills/use-discatsharp/references/modules.md
+++ b/skills/use-discatsharp/references/modules.md
@@ -1,0 +1,21 @@
+# DisCatSharp module map
+
+Use the consuming project and current documentation to confirm package names and versions. This map is for routing, not a substitute for API lookup.
+
+| Area | Primary package | Use it for |
+| --- | --- | --- |
+| Core | `DisCatSharp` | Clients, entities, events, Gateway state, REST operations, webhooks, and OAuth |
+| Slash and context commands | `DisCatSharp.ApplicationCommands` | Application-command registration, handlers, checks, autocomplete, and interaction responses |
+| Prefix commands | `DisCatSharp.CommandsNext` | Text/prefix command parsing, converters, checks, and execution |
+| Interaction helpers | `DisCatSharp.Interactivity` | Waiters, pagination, polls, collectors, and component flows |
+| Configuration models | `DisCatSharp.Configuration` | Configuration abstractions shared with hosting integrations |
+| Generic Host | `DisCatSharp.Hosting` | Hosted services and host-builder integration |
+| Dependency injection | `DisCatSharp.Hosting.DependencyInjection` | Registering clients and extensions with Microsoft DI |
+| ASP.NET Core | `DisCatSharp.Hosting.AspNetCore` | ASP.NET Core-specific hosting integration |
+| Lavalink | `DisCatSharp.Lavalink` | External Lavalink node connections and audio players |
+| Native voice | `DisCatSharp.Voice` | Discord voice connections and audio transport |
+| Voice natives | `DisCatSharp.Voice.Natives` | Native voice dependencies distributed with Voice |
+| Experimental | `DisCatSharp.Experimental` | Explicitly experimental Discord or library surfaces |
+| Analyzers | `DisCatSharp.Analyzer` | Compile-time migration and usage diagnostics |
+
+Do not add every package by default. Choose the smallest module set required by the feature and preserve the application's existing hosting model.


### PR DESCRIPTION
# Description

Adds portable Agent Skills for using and maintaining DisCatSharp, with shared instructions and documentation MCP setup for common coding agents.

Restores GitHub Release publishing through the existing manual release workflow. Releases now use package-derived versions, generated notes, checksums, build attestations, resumable drafts, and immutable asset verification.

This also documents the repository's 100% XML documentation goal and fixes prerelease versioning for the Attributes and Analyzer packages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Built all three package families, including .NET 9, 10, and 11 for DisCatSharp
- [x] Ran release helper tests, `actionlint`, skill validation, and the supported-client installation matrix

**Test Configuration**:
* Toolchain: .NET 9/10/11, Node.js 24, GitHub CLI and Agent Skills CLI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

@Aiko-IT-Systems/aitsys-leader
