### PR TITLE
Add application compliance diagnostics

### DIFF
--- a/DisCatSharp.Tests/DisCatSharp.CopilotTests/Application/ApplicationModelDeserializationTests.cs
+++ b/DisCatSharp.Tests/DisCatSharp.CopilotTests/Application/ApplicationModelDeserializationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using DisCatSharp.Entities;
 using DisCatSharp.Enums;
@@ -86,6 +87,58 @@ public class ApplicationModelDeserializationTests
 			],
 			application.ApprovedConsoles);
 		Assert.Equal("localized_price_sets", application.PricingLocalizationStrategy);
+	}
+
+	[Fact]
+	public void DiscordApplicationPayload_DeserializesReviewAndEligibleOAuth2Scopes()
+	{
+		const string json = """
+		                    {
+		                      "id": "891436243903728565",
+		                      "name": "Wordle",
+		                      "icon": null,
+		                      "description": "Official Wordle",
+		                      "owner": {
+		                        "id": "1110738998453837384",
+		                        "username": "owner",
+		                        "discriminator": "0001",
+		                        "avatar": null
+		                      },
+		                      "privileged_intents_review": {
+		                        "limited_intents_threshold_exceeded_at": "2026-08-13T18:01:28.637384+00:00",
+		                        "limited_intents_revocation_deadline": "2026-11-11T18:01:28.637384+00:00",
+		                        "has_submitted": false
+		                      },
+		                      "eligible_oauth2_scopes": ["bot", "applications.commands"]
+		                    }
+		                    """;
+
+		var application = new DiscordApplication(Deserialize<TransportApplication>(json));
+
+		Assert.NotNull(application.PrivilegedIntentsReview);
+		Assert.False(application.PrivilegedIntentsReview.HasSubmitted);
+		Assert.Equal(new DateTimeOffset(2026, 8, 13, 18, 1, 28, 637, TimeSpan.Zero).AddTicks(3840), application.PrivilegedIntentsReview.LimitedIntentsThresholdExceededAt);
+		Assert.Equal(new DateTimeOffset(2026, 11, 11, 18, 1, 28, 637, TimeSpan.Zero).AddTicks(3840), application.PrivilegedIntentsReview.LimitedIntentsRevocationDeadline);
+		Assert.Equal(["bot", "applications.commands"], application.EligibleOAuth2Scopes);
+	}
+
+	[Fact]
+	public void DiscordUserPayload_MapsVadColorIntegersToDiscordColors()
+	{
+		const string json = """
+		                    {
+		                      "id": "1110738998453837384",
+		                      "username": "user",
+		                      "discriminator": "0001",
+		                      "avatar": null,
+		                      "vad_colors": [16711680, 65280, 255]
+		                    }
+		                    """;
+
+		var user = new DiscordUser(Deserialize<TransportUser>(json));
+
+		Assert.Equal([16711680, 65280, 255], user.VadColorsInternal);
+		Assert.Equal(["#FF0000", "#00FF00", "#0000FF"], user.VadColors?.Select(color => color.ToString()));
 	}
 
 	private static T Deserialize<T>(string json)

--- a/DisCatSharp/Clients/BaseDiscordClient.cs
+++ b/DisCatSharp/Clients/BaseDiscordClient.cs
@@ -432,7 +432,12 @@ public abstract class BaseDiscordClient : IDisposable, IAsyncDisposable
 		}
 
 		if (this.Configuration.TokenType is TokenType.Bot && this.CurrentApplication is null)
+		{
 			this.CurrentApplication = await this.GetCurrentApplicationAsync(cancellationToken).ConfigureAwait(false);
+			this.LogPrivilegedIntentsReviewStatus(this.CurrentApplication);
+			this.LogPrivilegedIntentConfigurationStatus(this.CurrentApplication);
+			this.LogPrivacyPolicyStatus(this.CurrentApplication);
+		}
 
 		if (this.Configuration.TokenType is not TokenType.Bearer && this.InternalVoiceRegions.IsEmpty)
 		{
@@ -440,6 +445,101 @@ public abstract class BaseDiscordClient : IDisposable, IAsyncDisposable
 			foreach (var xvr in vrs)
 				this.InternalVoiceRegions.TryAdd(xvr.Id, xvr);
 		}
+	}
+
+	/// <summary>
+	///     Logs the privileged intents review state returned for the application during startup.
+	/// </summary>
+	/// <param name="application">The application whose review state was fetched.</param>
+	private void LogPrivilegedIntentsReviewStatus(DiscordApplication application)
+	{
+		var review = application.PrivilegedIntentsReview;
+		if (review is null)
+		{
+			this.Logger.LogInformation(LoggerEvents.Startup, "Discord did not report a pending privileged intents review for application {ApplicationId}; any previously submitted review is approved or no review is required", application.Id);
+			return;
+		}
+
+		var enabledPrivilegedIntentFlags = GetEnabledPrivilegedGatewayIntents(application.Flags);
+		var enabledPrivilegedIntents = enabledPrivilegedIntentFlags.Count > 0
+			? string.Join(", ", enabledPrivilegedIntentFlags)
+			: "not identified by application flags";
+		if (!review.HasSubmitted)
+		{
+			this.Logger.LogWarning(LoggerEvents.Startup, "Privileged intents review has not been submitted for application {ApplicationId}. Enabled privileged intents: {EnabledPrivilegedIntents}. The limited intents threshold was exceeded at {ThresholdExceededAt}; submit the review before its deadline at {ReviewDeadline} to avoid possible revocation of limited intent access", application.Id, enabledPrivilegedIntents, review.LimitedIntentsThresholdExceededAt, review.LimitedIntentsRevocationDeadline);
+			return;
+		}
+
+		this.Logger.LogInformation(LoggerEvents.Startup, "Privileged intents review is pending for application {ApplicationId}. Enabled privileged intents: {EnabledPrivilegedIntents}. The limited intents threshold was exceeded at {ThresholdExceededAt}; Discord's review deadline is {ReviewDeadline}", application.Id, enabledPrivilegedIntents, review.LimitedIntentsThresholdExceededAt, review.LimitedIntentsRevocationDeadline);
+	}
+
+	/// <summary>
+	///     Gets the privileged gateway intents that Discord reports as enabled for an application.
+	/// </summary>
+	/// <param name="flags">The application's flags returned by Discord.</param>
+	/// <returns>The enabled privileged gateway intents.</returns>
+	private static IReadOnlyList<DiscordIntents> GetEnabledPrivilegedGatewayIntents(ApplicationFlags flags)
+	{
+		List<DiscordIntents> intents = [];
+		if (flags.HasFlag(ApplicationFlags.GatewayGuildMembers) || flags.HasFlag(ApplicationFlags.GatewayGuildMembersLimited))
+			intents.Add(DiscordIntents.GuildMembers);
+		if (flags.HasFlag(ApplicationFlags.GatewayPresence) || flags.HasFlag(ApplicationFlags.GatewayPresenceLimited))
+			intents.Add(DiscordIntents.GuildPresences);
+		if (flags.HasFlag(ApplicationFlags.GatewayMessageContent) || flags.HasFlag(ApplicationFlags.GatewayMessageContentLimited))
+			intents.Add(DiscordIntents.MessageContent);
+
+		return intents;
+	}
+
+	/// <summary>
+	///     Logs differences between the privileged gateway intents enabled for the application in Discord and those requested by this client.
+	/// </summary>
+	/// <param name="application">The application whose enabled gateway intent flags were fetched.</param>
+	private void LogPrivilegedIntentConfigurationStatus(DiscordApplication application)
+	{
+		var portalIntents = GetEnabledPrivilegedGatewayIntents(application.Flags);
+		var configuredIntents = GetConfiguredPrivilegedGatewayIntents(this.Configuration.Intents);
+		var enabledButNotRequested = portalIntents.Except(configuredIntents).ToArray();
+		var requestedButNotEnabled = configuredIntents.Except(portalIntents).ToArray();
+
+		if (enabledButNotRequested.Length > 0)
+			this.Logger.LogInformation(LoggerEvents.Intents, "Application {ApplicationId} enables privileged intents in Discord that this client does not request: {EnabledButNotRequested}. Consider disabling them in the Developer Portal if no other deployment needs them", application.Id, string.Join(", ", enabledButNotRequested));
+
+		if (requestedButNotEnabled.Length > 0)
+			this.Logger.LogWarning(LoggerEvents.Intents, "Application {ApplicationId} requests privileged intents that Discord does not report as enabled: {RequestedButNotEnabled}. Enable them in the Developer Portal before connecting", application.Id, string.Join(", ", requestedButNotEnabled));
+	}
+
+	/// <summary>
+	///     Gets the privileged gateway intents requested by a client configuration.
+	/// </summary>
+	/// <param name="intents">The configured gateway intents.</param>
+	/// <returns>The configured privileged gateway intents.</returns>
+	private static IReadOnlyList<DiscordIntents> GetConfiguredPrivilegedGatewayIntents(DiscordIntents intents)
+	{
+		List<DiscordIntents> configuredIntents = [];
+		if (intents.HasIntent(DiscordIntents.GuildMembers))
+			configuredIntents.Add(DiscordIntents.GuildMembers);
+		if (intents.HasIntent(DiscordIntents.GuildPresences))
+			configuredIntents.Add(DiscordIntents.GuildPresences);
+		if (intents.HasIntent(DiscordIntents.MessageContent))
+			configuredIntents.Add(DiscordIntents.MessageContent);
+
+		return configuredIntents;
+	}
+
+	/// <summary>
+	///     Logs whether the application has a privacy policy URL configured in Discord.
+	/// </summary>
+	/// <param name="application">The application whose privacy policy configuration was fetched.</param>
+	private void LogPrivacyPolicyStatus(DiscordApplication application)
+	{
+		if (string.IsNullOrWhiteSpace(application.PrivacyPolicyUrl))
+		{
+			this.Logger.LogWarning(LoggerEvents.Startup, "Application {ApplicationId} has no privacy policy URL configured in Discord", application.Id);
+			return;
+		}
+
+		this.Logger.LogInformation(LoggerEvents.Startup, "Application {ApplicationId} privacy policy URL: {PrivacyPolicyUrl}", application.Id, application.PrivacyPolicyUrl);
 	}
 
 	/// <summary>

--- a/DisCatSharp/Clients/DiscordClient.cs
+++ b/DisCatSharp/Clients/DiscordClient.cs
@@ -1519,9 +1519,11 @@ public sealed partial class DiscordClient : BaseDiscordClient
 	public Uri GetInAppOAuth(Permissions permissions = Permissions.None, OAuthScopes scopes = OAuthScopes.BOT_DEFAULT, string? redir = null, bool user_install = false, ulong? guild_id = null, string? state = null, string? access_type = null, string? response_type = null, bool prompt = true, string? manual_scopes = null)
 	{
 		permissions &= PermissionMethods.FullPerms;
+		var requestedScopes = manual_scopes ?? OAuth.ResolveScopes(scopes);
+		this.WarnForIneligibleOAuth2Scopes(this.CurrentApplication, requestedScopes);
 		return new(new QueryUriBuilder($"{DiscordDomain.GetDomain(CoreDomain.Discord).Url}{Endpoints.OAUTH2}{Endpoints.AUTHORIZE}")
 			.AddParameter("client_id", this.CurrentApplication.Id.ToString(CultureInfo.InvariantCulture))
-			.AddParameter("scope", manual_scopes ?? OAuth.ResolveScopes(scopes))
+			.AddParameter("scope", requestedScopes)
 			.AddParameter("permissions", ((long)permissions).ToString(CultureInfo.InvariantCulture))
 			.AddParameter("state", state ?? string.Empty)
 			.AddParameter("redirect_uri", redir ?? string.Empty)
@@ -1557,9 +1559,12 @@ public sealed partial class DiscordClient : BaseDiscordClient
 			throw new ArgumentException("The user must be a bot.", nameof(bot));
 
 		permissions &= PermissionMethods.FullPerms;
+		var requestedScopes = manual_scopes ?? OAuth.ResolveScopes(scopes);
+		if (this.CurrentApplication?.Id == bot.Id)
+			this.WarnForIneligibleOAuth2Scopes(this.CurrentApplication, requestedScopes);
 		return new(new QueryUriBuilder($"{DiscordDomain.GetDomain(CoreDomain.Discord).Url}{Endpoints.OAUTH2}{Endpoints.AUTHORIZE}")
 			.AddParameter("client_id", bot.Id.ToString(CultureInfo.InvariantCulture))
-			.AddParameter("scope", manual_scopes ?? OAuth.ResolveScopes(scopes))
+			.AddParameter("scope", requestedScopes)
 			.AddParameter("permissions", ((long)permissions).ToString(CultureInfo.InvariantCulture))
 			.AddParameter("state", state ?? string.Empty)
 			.AddParameter("redirect_uri", redir ?? string.Empty)
@@ -1569,6 +1574,26 @@ public sealed partial class DiscordClient : BaseDiscordClient
 			.AddParameter("response_type", response_type ?? string.Empty)
 			.AddParameter("prompt", prompt ? "consent" : "none")
 			.ToString());
+	}
+
+	/// <summary>
+	///     Warns when an OAuth2 authorization URL requests scopes that Discord did not report as eligible for the application.
+	/// </summary>
+	/// <param name="application">The application whose eligible OAuth2 scopes are known.</param>
+	/// <param name="requestedScopes">The space-delimited OAuth2 scopes requested by the authorization URL.</param>
+	private void WarnForIneligibleOAuth2Scopes(DiscordApplication? application, string requestedScopes)
+	{
+		if (application?.EligibleOAuth2Scopes.Count is not > 0)
+			return;
+
+		var ineligibleScopes = requestedScopes
+			.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.Where(scope => !application.EligibleOAuth2Scopes.Contains(scope, StringComparer.Ordinal))
+			.ToArray();
+		if (ineligibleScopes.Length is 0)
+			return;
+
+		this.Logger.LogWarning(LoggerEvents.Misc, "OAuth2 URL for application {ApplicationId} requests scopes Discord did not report as eligible: {IneligibleScopes}", application.Id, string.Join(", ", ineligibleScopes));
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Description

Adds startup diagnostics for privileged-intent review, portal/configuration intent mismatches, privacy-policy status, and ineligible OAuth2 scopes. Includes VAD color mapping regression coverage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `dotnet test DisCatSharp.Tests/DisCatSharp.CopilotTests/DisCatSharp.CopilotTests.csproj --no-restore --filter FullyQualifiedName~ApplicationModelDeserializationTests`

**Test Configuration**:
* Toolchain: .NET SDK
* Frameworks: net9.0, net10.0, net11.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

@Aiko-IT-Systems/discatsharp-reviewer