### PR TITLE
fix: member cache fields for joinedAt & PremiumSince

### DIFF
--- a/DisCatSharp/Clients/DiscordClient.Dispatch.cs
+++ b/DisCatSharp/Clients/DiscordClient.Dispatch.cs
@@ -2592,7 +2592,7 @@ public sealed partial class DiscordClient
 		});
 
 		if (!guild.Members.TryGetValue(member.User.Id, out var mbr))
-			mbr = new(usr)
+			mbr = new(member)
 			{
 				Discord = this,
 				GuildId = guild.Id
@@ -2621,6 +2621,9 @@ public sealed partial class DiscordClient
 		mbr.IsPending = pending;
 		mbr.CommunicationDisabledUntil = member.CommunicationDisabledUntil;
 		mbr.UnusualDmActivityUntil = member.UnusualDmActivityUntil;
+		mbr.PremiumSince = member.PremiumSince;
+		if (member.JoinedAt != default)
+			mbr.JoinedAt = member.JoinedAt;
 		mbr.RoleIdsInternal.Clear();
 		mbr.RoleIdsInternal.AddRange(roles);
 		guild.MembersInternal.AddOrUpdate(member.User.Id, mbr, (id, oldMbr) => oldMbr);

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -32,6 +32,7 @@ DisCatSharp Release Notes
     - Renamed `deleteMessageDays` to `deleteMessageSeconds` on `DiscordMember.BanAsync` and all `DiscordGuild.BanMemberAsync` overloads; removed the legacy days-to-seconds compatibility shim — the API has always accepted seconds. **Note:** positional callers passing day values must be updated manually; named-argument callers are handled by `DCS1102`.
     - Padded log-level labels to eight characters in `DefaultLogger` for consistent column alignment across log lines.
     - Fixed `DiscordEventArgs` scoped service scope to be properly disposed after event dispatch, preventing scoped service leaks on high-volume bots.
+    - Fixed `GUILD_MEMBER_UPDATE` dropping `premium_since` and `joined_at` when updating a cached member, and building an uncached member from the user instead of the transport payload — a member who started boosting while cached kept a stale `DiscordMember.PremiumSince` indefinitely.
 
     - Overhauled presence caching and added follow-up regression coverage around gateway cache behavior.
     - Added Discord parity updates for store, entitlement, SKU, guild powerup / applied boost, application, audit-log, automod, message-type, and OAuth scope surfaces.


### PR DESCRIPTION
# Description

`OnGuildMemberUpdateEventAsync` leaves parts of the cached member stale. There are two separate problems.

**1. `premium_since` is never applied to a cached member.**

The handler mutates the cached `DiscordMember` in place. It copies `MemberFlags`, the avatar and banner hashes, `Nickname`, `GuildPronouns`, `IsPending`, the timeout fields and the roles, but not `premium_since`. `DiscordMember.PremiumSince` is assigned only in the `DiscordMember(TransportMember)` constructor. A member who starts or stops boosting after they were cached keeps the value they were first cached with, until something replaces the entry: a `GUILD_MEMBERS_CHUNK`, `GetAllMembersAsync`, or `GetMemberAsync(id, fetch: true)`.

For a bot that gates a feature on `member.PremiumSince`, a user who just boosted is told they are not a booster. The same check usually drives the cleanup path as well, so a reward granted earlier can be revoked again the next time any member update fires for that user.

**2. An uncached member is built from the wrong constructor.**

When the event arrives for a member that is not in the cache, the entry is created with `new DiscordMember(DiscordUser)`, which copies the identity and nothing else. The handler then fills in part of the payload by hand, so `JoinedAt`, `PremiumSince`, `IsDeafened`, `IsMuted`, `GuildBio`, `InteractionPermissions` and `GuildDisplayNameStyles` stay at their defaults. A `JoinedAt` of `DateTime.MinValue` is the most visible result.

This handler is the only member caching path that does that. `READY`, `GUILD_MEMBER_ADD`, `GUILD_MEMBERS_CHUNK`, resolved interaction members, `UpdateUser`, `UpdateCachedGuild` and `GetAllMembersAsync` all build from the transport member already.

## Changes

- Copy `member.PremiumSince` onto the cached member on every update.
- Copy `member.JoinedAt` when the payload carries it. The transport property is not nullable, so an omitted `joined_at` would overwrite a known join date with `DateTime.MinValue`. The guard keeps the existing value in that case.
- Build a not yet cached member with `new DiscordMember(TransportMember)` instead of `new DiscordMember(DiscordUser)`, which is what the other caching paths do.

The transport constructor covers 20 of the 21 `TransportMember` properties. The remaining one, `GuildId`, is set by the object initializer immediately after, so no field is dropped.

## Notes for reviewers

- `ManualUser` now holds a `DiscordUser` built from the payload instead of the cached instance. `DiscordMember.User` resolves through `Discord.UserCache` first and only falls back to `ManualUser`. The handler writes the user into `UserCache` two statements earlier, and `UserCache` has no eviction path anywhere in the library, so the fallback is not reached here. The other seven caching sites behave the same way.
- For a member that was not cached before the event, the `*Before` values on `GuildMemberUpdateEventArgs` now equal the `*After` values instead of reporting an empty role set and null fields. Both are made up for an entity the library has never seen. "Nothing changed" looked less misleading than "gained every role at once", but I can restore the old shape if you want the event args left untouched.

No dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] **Full test suite on all target frameworks.** `dotnet test DisCatSharp.Tests/DisCatSharp.CopilotTests/DisCatSharp.CopilotTests.csproj`: 377 passed, 0 failed on each of `net9.0`, `net10.0` and `net11.0`. `DisCatSharp.EventHandlers.Tests` (9 passed) and `DisCatSharp.SafetyTests` (1 passed) are clean on all three as well.
- [x] **Build on the full target matrix.** `dotnet build DisCatSharp.Tests/DisCatSharp.CopilotTests/DisCatSharp.CopilotTests.csproj` succeeds for `net9.0`, `net10.0` and `net11.0` with 0 warnings and 0 errors.
- [x] **Regression tests against the unpatched handler.** Four tests were written against `OnGuildMemberUpdateEventAsync` while working on the fix: applying `premium_since` to a cached member, clearing it again, keeping `JoinedAt` when the payload omits it, and caching a complete member on an update for an uncached one. Three of the four fail on `main`, all four pass with this change. The file was removed before submitting, so this PR contains no tests. I can add them back under `DisCatSharp.Tests/DisCatSharp.CopilotTests/` if you want them in.

To reproduce without tests: cache a member who is not boosting, have them boost, then read `guild.Members[id].PremiumSince` after the `GUILD_MEMBER_UPDATE` arrives. It stays `null` on `main`.

**Test Configuration**:
* Firmware version: n/a
* Hardware: x86_64
* Toolchain: .NET SDK 11.0.100-rc.1 (`mcr.microsoft.com/dotnet/nightly/sdk:11.0-preview`), runtime 11.0.0-rc.1.26411.119, rolling forward for the `net9.0` and `net10.0` test hosts
* SDK: DisCatSharp `main` at `a4b6b0a32`, targeting `net9.0`, `net10.0` and `net11.0`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas. Not done on purpose. The change is four lines and the surrounding handler has no inline comments.
- [x] I have made corresponding changes to the documentation. `RELEASENOTES.md` only.
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules. None needed, the change is self contained.

@Aiko-IT-Systems/discatsharp-reviewer
